### PR TITLE
Check repo in DB before file extraction

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -220,4 +220,25 @@ export class ApiService {
 
     return this.handleResponse<any>(response);
   }
-} 
+
+  static async getRepositoryByUrl(repoUrl: string): Promise<any | null> {
+    const url = `${API_BASE_URL}/filedeps/repositories?repo_url=${encodeURIComponent(repoUrl)}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: this.getAuthHeaders(),
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    return this.handleResponse<any>(response);
+  }
+
+  static async getRepositoryFiles(repositoryId: number): Promise<any[]> {
+    const response = await fetch(`${API_BASE_URL}/filedeps/repositories/${repositoryId}/files`, {
+      method: 'GET',
+      headers: this.getAuthHeaders(),
+    });
+
+    return this.handleResponse<any[]>(response);
+  }
+}


### PR DESCRIPTION
## Summary
- check database for repository data before calling extract endpoint
- add helpers to build file tree from stored DB results
- show skeleton loader while loading
- extend `ApiService` with database retrieval methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7edfc12c8327852bcf982ff13094