### PR TITLE
Add repository lookup endpoint

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -109,7 +109,9 @@ class Repository(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     owner: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     full_name: Mapped[str] = mapped_column(String(512), nullable=False, index=True)
-    repo_url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # Original repository URL
+    repo_url: Mapped[Optional[str]] = mapped_column(
+        String(500), unique=True, index=True, nullable=True
+    )  # Original repository URL
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     private: Mapped[bool] = mapped_column(Boolean, default=False)
     html_url: Mapped[str] = mapped_column(String(500), nullable=False)

--- a/backend/repo_processorGitIngest/filedeps.py
+++ b/backend/repo_processorGitIngest/filedeps.py
@@ -25,9 +25,10 @@ from models import (
     RepositoryRequest,
     FileItemResponse,
     Repository,
+    RepositoryResponse,
     FileAnalysis,
     FileItem,
-    FileItemDBResponse
+    FileItemDBResponse,
 )
 
 # Import functions from scraper_script.py
@@ -368,9 +369,21 @@ async def root():
         "version": "1.0.0",
         "endpoints": {
             "/extract": "Extract repository data and return file dependencies",
+            "/repositories": "Get repository by URL",
             "/repositories/{id}/files": "Get all files for a specific repository"
         }
     }
+
+
+@router.get("/repositories", response_model=RepositoryResponse)
+async def get_repository_by_url(
+    repo_url: str, db: Session = Depends(get_db)
+):
+    """Retrieve a repository by its exact URL."""
+    repository = db.query(Repository).filter(Repository.repo_url == repo_url).first()
+    if not repository:
+        raise HTTPException(status_code=404, detail="Repository not found")
+    return repository
 
 @router.get("/repositories/{repository_id}/files", response_model=List[FileItemDBResponse])
 async def get_repository_files(

--- a/backend/tests/test_github_api_integration.py
+++ b/backend/tests/test_github_api_integration.py
@@ -334,6 +334,28 @@ class TestRepositoryDataIntegration:
         assert main_file["is_directory"] is False
         assert main_file["tokens"] == 1000
 
+    def test_get_repository_by_url(self, test_client, auth_headers, dummy_repository):
+        """Repository can be retrieved by exact URL"""
+        response = test_client.get(
+            "/repositories",
+            params={"repo_url": dummy_repository.repo_url},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["repo_url"] == dummy_repository.repo_url
+        assert data["repo_name"] == dummy_repository.repo_name
+
+    def test_get_repository_by_url_not_found(self, test_client, auth_headers):
+        """404 returned when repository does not exist"""
+        response = test_client.get(
+            "/repositories",
+            params={"repo_url": "https://github.com/does/not-exist"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+
 
 class TestEndToEndIntegration:
     """Test end-to-end integration scenarios"""

--- a/context/APIDOCS.md
+++ b/context/APIDOCS.md
@@ -112,6 +112,7 @@ The server will be available at:
 ### File Dependencies
 - `GET /filedeps/` - File dependencies API info
 - `GET /filedeps/repositories` - User repositories
+- `GET /filedeps/repositories?repo_url=<url>` - Repository lookup by URL
 - `GET /filedeps/repositories/{repository_id}` - Repository details
 - `GET /filedeps/repositories/{repository_id}/files` - Repository files
 - `POST /filedeps/extract` - Extract file dependencies

--- a/repo_processor/__init__.py
+++ b/repo_processor/__init__.py
@@ -1,0 +1,1 @@
+from .filedeps import app

--- a/repo_processor/filedeps.py
+++ b/repo_processor/filedeps.py
@@ -1,0 +1,5 @@
+from fastapi import FastAPI
+from backend.repo_processorGitIngest.filedeps import router
+
+app = FastAPI()
+app.include_router(router)

--- a/repo_processor/scraper_script.py
+++ b/repo_processor/scraper_script.py
@@ -1,0 +1,1 @@
+from backend.repo_processorGitIngest.scraper_script import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add unique index to `repo_url` column
- implement `/repositories` lookup endpoint
- document new endpoint
- create compatibility wrapper modules for tests
- adjust fixtures and add integration tests

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_github_api_integration.py::TestRepositoryDataIntegration::test_get_repository_by_url -q`
- `PYTHONPATH=backend pytest backend/tests/test_github_api_integration.py::TestRepositoryDataIntegration::test_get_repository_by_url_not_found -q`


------
https://chatgpt.com/codex/tasks/task_e_687f91182e208327be6f5dfdaf041bb3