### PR TITLE
Fix GitHub OAuth redirect

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -376,7 +376,7 @@ services:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
-      - GITHUB_REDIRECT_URI=https://${DOMAIN}/auth/callback
+      - GITHUB_REDIRECT_URI=https://${DOMAIN}/
       - SECRET_KEY=${SECRET_KEY}
       - JWT_SECRET=${JWT_SECRET}
       - NODE_ENV=production

--- a/backend/auth/github_oauth.py
+++ b/backend/auth/github_oauth.py
@@ -26,7 +26,9 @@ security = HTTPBearer()
 # GitHub OAuth Configuration
 GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID")
 GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET")
-GITHUB_REDIRECT_URI = os.getenv("GITHUB_REDIRECT_URI", "https://yudai.app/auth/callback")
+# Redirect back to the frontend root where the React app can
+# handle the OAuth callback and exchange the code for a token
+GITHUB_REDIRECT_URI = os.getenv("GITHUB_REDIRECT_URI", "https://yudai.app/")
 GITHUB_AUTH_URL = "https://github.com/login/oauth/authorize"
 GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
 GITHUB_USER_API_URL = "https://api.github.com/user"

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,7 +28,7 @@ print_error() {
 
 # Check if .env file exists
 if [ ! -f .env ]; then
-    print_error ".env file not found. Please create it from .env.example"
+    print_error ".env file not found. Please create it following the deployment guide"
     exit 1
 fi
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,7 +37,7 @@ services:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
-      - GITHUB_REDIRECT_URI=https://yudai.app/auth/callback
+      - GITHUB_REDIRECT_URI=https://yudai.app/
       - API_DOMAIN=api.yudai.app
       - DEV_DOMAIN=dev.yudai.app
       - SECRET_KEY=${SECRET_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-dummy_key}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-dummy_id}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-dummy_secret}
-      - GITHUB_REDIRECT_URI=http://localhost:5173/auth/callback
+      - GITHUB_REDIRECT_URI=http://localhost:5173/
     ports:
       - "8000:8000"
     depends_on:

--- a/tests/README.md
+++ b/tests/README.md
@@ -225,7 +225,7 @@ The tests verify these key endpoints:
 
 For GitHub authentication to work properly, ensure your GitHub OAuth App is configured with:
 
-**Authorization callback URL:** `https://yudai.app/auth/callback`
+**Authorization callback URL:** `https://yudai.app/`
 
 This matches the `GITHUB_REDIRECT_URI` environment variable in your `docker-compose.prod.yml`.
 


### PR DESCRIPTION
## Summary
- update GitHub OAuth redirect URI to send users back to frontend root
- clarify `.env` message in deploy script
- document new redirect URI in Deployment Guide and test docs

## Testing
- `npm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886dd1781ec83279c1c35165d75ca63