### PR TITLE
refactor: centralize session context management

### DIFF
--- a/src/hooks/useSessionState.ts
+++ b/src/hooks/useSessionState.ts
@@ -91,6 +91,7 @@ export const useChatMessageManagement = () => {
     updateChatMessage: session.updateChatMessage,
     clearChatMessages: session.clearChatMessages,
     loadChatMessages: session.loadChatMessages,
+    deleteChatMessage: session.deleteChatMessage,
   };
 };
 
@@ -103,6 +104,21 @@ export const useFileDependencyManagement = () => {
   return {
     addFileDependency: session.addFileDependency,
     addMultipleFileDependencies: session.addMultipleFileDependencies,
+    loadFileDependencies: session.loadFileDependencies,
+    deleteFileDependency: session.deleteFileDependency,
+    extractFileDependenciesForSession: session.extractFileDependenciesForSession,
+  };
+};
+
+/**
+ * Helper hook to get context card management functions
+ */
+export const useContextCardManagement = () => {
+  const session = useSession();
+  return {
+    addContextCard: session.addContextCard,
+    removeContextCard: session.removeContextCard,
+    loadContextCards: session.loadContextCards,
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,13 +358,14 @@ export interface SessionContextValue extends UnifiedSessionState {
   hasSelectedRepository: boolean;
   clearSelectedRepository: () => void;
   loadRepositories: () => Promise<void>;
-  
+
   // Chat message management methods
-  addChatMessage: (message: ChatMessageAPI) => void;
+  addChatMessage: (message: ChatMessageAPI) => Promise<void>;
   updateChatMessage: (messageId: string, updates: Partial<ChatMessageAPI>) => void;
   clearChatMessages: () => void;
-  loadChatMessages: (sessionId: string) => ChatMessageAPI[];
-  
+  loadChatMessages: (sessionId: string) => Promise<void>;
+  deleteChatMessage: (messageId: string) => Promise<void>;
+
   // File dependency management methods
   addFileDependency: (fileDependency: {
     file_path: string;
@@ -382,6 +383,20 @@ export interface SessionContextValue extends UnifiedSessionState {
     tokens: number;
     file_metadata?: Record<string, unknown>;
   }>) => Promise<void>;
+  loadFileDependencies: () => Promise<void>;
+  deleteFileDependency: (fileId: string) => Promise<void>;
+  extractFileDependenciesForSession: (repoUrl: string) => Promise<void>;
+
+  // Context card management methods
+  addContextCard: (card: {
+    title: string;
+    description: string;
+    source: 'chat' | 'file-deps' | 'upload';
+    tokens: number;
+    content?: string;
+  }) => Promise<void>;
+  removeContextCard: (cardId: string) => Promise<void>;
+  loadContextCards: (sessionId: string) => Promise<void>;
 }
 
 // GitHub Issue Context Structure

--- a/zustand-query-unifier.md
+++ b/zustand-query-unifier.md
@@ -1,0 +1,59 @@
+# Zustand & TanStack Query State Flow
+
+This document summarizes how a minimal state layer can unify **Zustand** for local UI state and **TanStack React Query** for server interactions. Inspired by the tic‑tac‑toe example in the Zustand docs, it outlines basic CRUD flows that keep implementation approachable while avoiding manual context wiring. The game example is **conceptual only**—no Tic‑Tac‑Toe code ships in this repo; it simply illustrates a style for implementing CRUD-style state changes.
+
+## State Flow Diagram
+```mermaid
+flowchart TD
+  A[User action] -->|trigger| B[Zustand store]
+  B -->|re-render| C[React components]
+  A -->|async change| D[useMutation]
+  D --> E[Server API]
+  E --> F[useQuery]
+  F -->|update cache| B
+  F -->|provide data| C
+```
+
+## Learnings & Insights
+- **Zustand handles view state**: board positions, active player, and ephemeral UI flags live in a small store (`useBoardStore`). Components subscribe directly without provider boilerplate.
+- **React Query manages server state**: `useBoardQuery` hydrates the store from `/api/board`, while `useSaveBoard` persists moves and invalidates cached queries.
+- **Clear separation** keeps logic simple: local updates happen instantly in the store, and network side-effects remain declarative through queries and mutations.
+- **Extensibility**: the same pattern can be expanded for chat sessions—messages, context cards, and file dependencies—where the store exposes synchronous mutations and React Query encapsulates all API traffic.
+- **Improvement ideas**: co-locate query keys with store slices, derive optimistic updates from store actions, and expose a testing utility that resets both React Query cache and Zustand store for deterministic tests.
+
+## Backend API Alignment
+
+The frontend's Zustand + React Query layer calls a unified FastAPI server (`run_server.py`) that mounts several routers:
+
+- `session_router` and `session_components_router` for session metadata, chat messages, context cards and file embeddings
+- `daifu_router` for chat completion and issue creation
+- `github_router` for repository data and GitHub issue operations
+- `issue_router` and `filedeps_router` for user-generated issues and repository file analysis
+
+### Existing Endpoints
+
+- **Sessions** – create a session and fetch full context (`/daifu/sessions`, `/daifu/sessions/{id}`)
+- **Session components** – add/get/delete chat messages, context cards and file dependencies
+- **Chat** – synchronous `/daifu/chat` that persists messages and `/daifu/create-issue`
+- **GitHub** – repository listing, details, branches, commits, pulls and issue creation
+- **File dependencies** – repository scraping to populate file embeddings
+
+### Missing Functions to Implement
+
+To support full CRUD cycles from the frontend, additional backend operations are required:
+
+- **Sessions**
+  - `list_sessions(user)` – enumerate all sessions for the authenticated user
+  - `update_session(session_id, updates)` – modify title, description or repository info
+  - `delete_session(session_id)` – archive/remove a session and its components
+- **Chat messages**
+  - `update_chat_message(session_id, message_id, updates)` – edit message content/metadata
+  - `bulk_add_chat_messages(session_id, messages)` – batch persistence when restoring history
+- **Context cards**
+  - `update_context_card(session_id, card_id, updates)` – change title, description or content
+  - `bulk_add_context_cards(session_id, cards)` – create multiple cards in one call
+- **File dependencies**
+  - `update_file_dependency(session_id, file_id, updates)` – revise path, tokens or metadata
+  - `bulk_add_file_dependencies(session_id, deps)` – add many embeddings at once
+
+Each function would require SQLAlchemy operations in `models.py`, corresponding routes in the appropriate router, and inclusion in `run_server.py` so the frontend can invoke them through React Query.


### PR DESCRIPTION
## Summary
- prevent duplicate session creation in chat and add context cards via provider
- load file dependencies from session context and support extraction on demand
- expose CRUD operations for messages, context cards, and file dependencies in SessionProvider
- document unified Zustand + React Query flow with backend API alignment and missing CRUD functions

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7605b19488327b21ba1b9b1ef6fc8