### PR TITLE
chore: proxy sessions through api prefix

### DIFF
--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -103,8 +103,8 @@ server {
         # No CORS headers here - FastAPI handles them
     }
     
-    # WebSocket support
-    location /daifu/sessions/ {
+    # WebSocket session endpoints - proxy to backend
+    location /api/daifu/sessions/ {
         proxy_pass http://backend:8000/daifu/sessions/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -113,7 +113,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
+
         # No CORS headers here - FastAPI handles them
     }
     


### PR DESCRIPTION
## Summary
- proxy WebSocket sessions through `/api/daifu/sessions/`
- keep general `/api/` proxy for remaining backend routes

## Testing
- `pnpm test` *(fails: No test files found)*
- `nginx -t -c /workspace/YudaiV3/nginx.prod.conf` *(fails: host not found in upstream "backend")*
- `nginx -s reload -c /workspace/YudaiV3/nginx.prod.conf` *(fails: host not found in upstream "backend")*


------
https://chatgpt.com/codex/tasks/task_e_68aa0351aad8832794f3e8fc5127b96c