### PR TITLE
chore: sync frontend/base URLs across services

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,3 @@
+FRONTEND_BASE_URL=https://yudai.app
+GITHUB_REDIRECT_URI=https://yudai.app/auth/callback
+VITE_API_BASE_URL=/api

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN npm install -g pnpm
 WORKDIR /app
 
 # Accept build args for environment variables
-ARG VITE_API_URL
-ENV VITE_API_URL=$VITE_API_URL
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 # Copy package files
 COPY package*.json pnpm-lock.yaml* ./

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pnpm install
 - **Local Backend**: Ensure the Python backend is running locally. Refer to the [backend setup guide](#backend-setup) (TBD: link to backend-specific instructions).
 - **Hosted Backend**: Create a `.env` file in the project root and add:
   ```bash
-  VITE_API_URL=https://your-backend-api-url.com
+  VITE_API_BASE_URL=https://your-backend-api-url.com
   ```
   Replace `https://your-backend-api-url.com` with your hosted backend URL.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -98,7 +98,8 @@ services:
       - GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}
       - GITHUB_APP_INSTALLATION_ID=${GITHUB_APP_INSTALLATION_ID}
       - GITHUB_APP_PRIVATE_KEY_PATH=/app/yudaiv3.2025-08-02.private-key.pem
-      - GITHUB_REDIRECT_URI=https://yudai.app/auth/callback
+      - FRONTEND_BASE_URL=${FRONTEND_BASE_URL}
+      - GITHUB_REDIRECT_URI=${GITHUB_REDIRECT_URI}
       - API_DOMAIN=api.yudai.app
       - DEV_DOMAIN=dev.yudai.app
       - SECRET_KEY=${SECRET_KEY}
@@ -163,11 +164,11 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - VITE_API_URL=/api
+        - VITE_API_BASE_URL=${VITE_API_BASE_URL}
     container_name: yudai-fe
     restart: unless-stopped
     environment:
-      - VITE_API_URL=/api
+      - VITE_API_BASE_URL=${VITE_API_BASE_URL}
       - NGINX_WORKER_PROCESSES=auto
       - NGINX_WORKER_CONNECTIONS=1024
     ports:

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,7 +2,7 @@
 
 // Environment variables
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string;
+  readonly VITE_API_BASE_URL: string;
   readonly VITE_APP_TITLE: string;
   readonly MODE: string;
   readonly DEV: boolean;


### PR DESCRIPTION
## Summary
- align frontend build args and env vars around `VITE_API_BASE_URL`
- supply backend with `FRONTEND_BASE_URL` and `GITHUB_REDIRECT_URI`
- add production env file for shared deployment settings

## Testing
- `pnpm lint`
- `pnpm test` *(fails: No test files found)*
- `pytest`
- `docker compose -f docker-compose.prod.yml build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68aa035ee30c8327bbb25d42bc215f8c