### PR TITLE
refactor: simplify auth tokens and centralize DB config

### DIFF
--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -40,7 +40,7 @@ Create and configure your development environment files:
 #### `.env.dev` (Development Environment Variables)
 ```bash
 # Database Configuration
-POSTGRES_DB=yudai_dev
+POSTGRES_DB=your_dev_db
 POSTGRES_USER=yudai_user
 POSTGRES_PASSWORD=yudai_password
 
@@ -98,7 +98,7 @@ ls -la ./backend/yudaiv3.2025-08-02.private-key.pem
 |---------|-----|---------|
 | **Frontend** | http://localhost:3000 | React application with hot reload |
 | **Backend API** | http://localhost:8001 | FastAPI backend with debug logging |
-| **Database** | localhost:5433 | PostgreSQL (yudai_dev, yudai_user, yudai_password) |
+| **Database** | localhost:5433 | PostgreSQL (${POSTGRES_DB}, yudai_user, yudai_password) |
 | **Health Check** | http://localhost:3000/health | Frontend health endpoint |
 
 ## 🐳 Development Docker Configuration
@@ -157,8 +157,8 @@ docker compose -f docker-compose.prod.yml logs -f
 # ===========================================
 
 # Database Configuration
-POSTGRES_DB=yudai_prod
-POSTGRES_USER=yudai_prod_user
+POSTGRES_DB=your_prod_db
+POSTGRES_USER=your_prod_user
 POSTGRES_PASSWORD=your_secure_prod_password
 
 # API Configuration
@@ -278,7 +278,7 @@ dev.yudai.app  -> YOUR_SERVER_IP
 
 | Variable | Development | Production | Purpose |
 |----------|-------------|------------|---------|
-| `POSTGRES_DB` | yudai_dev | ${POSTGRES_DB} | Database name |
+| `POSTGRES_DB` | your_dev_db | ${POSTGRES_DB} | Database name |
 | `DEBUG` | true | false | Debug logging |
 | `DB_ECHO` | true | false | SQL query logging |
 | `VITE_API_BASE_URL` | http://localhost:8001 | https://api.yudai.app | Frontend API URL |
@@ -365,7 +365,7 @@ lsof -i :5433
 #### Database Connection Issues
 ```bash
 # Connect directly to database
-docker compose -f docker-compose-dev.yml exec db psql -U yudai_user -d yudai_dev
+docker compose -f docker-compose-dev.yml exec db psql -U yudai_user -d $POSTGRES_DB
 
 # Reset database
 docker compose -f docker-compose-dev.yml down -v

--- a/backend/db/Dockerfile
+++ b/backend/db/Dockerfile
@@ -1,11 +1,7 @@
 FROM postgres:15-alpine
 
-# Set environment variables for database
-ENV POSTGRES_DB=yudai_db
-ENV POSTGRES_USER=yudai_user
-ENV POSTGRES_PASSWORD=yudai_password
-
-# Set PostgreSQL configuration
+# Set environment variables for database (provided at runtime)
+# Postgres configuration
 ENV POSTGRES_INITDB_ARGS="--encoding=UTF8 --locale=C"
 ENV POSTGRES_HOST_AUTH_METHOD=trust
 

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -13,10 +13,9 @@ from sqlalchemy.orm import sessionmaker
 from utils import utc_now
 
 # Database URL from environment variables
-DATABASE_URL = os.getenv(
-    "DATABASE_URL", 
-    "postgresql://yudai_user:yudai_password@db:5432/yudai_db"
-)
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise ValueError("DATABASE_URL environment variable is required")
 
 # Create engine with standard configuration
 engine = create_engine(

--- a/backend/db/init.sql
+++ b/backend/db/init.sql
@@ -6,8 +6,6 @@
 -- Create the database if it doesn't exist (PostgreSQL creates it automatically from env vars)
 -- But we can add any additional setup here
 
--- Grant necessary permissions
-GRANT ALL PRIVILEGES ON DATABASE yudai_db TO yudai_user;
 
 -- Create extensions for enhanced functionality
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
@@ -37,7 +35,6 @@ ALTER SYSTEM SET statement_timeout = '30s';
 
 -- Set timezone globally
 SET timezone = 'UTC';
-ALTER DATABASE yudai_db SET timezone = 'UTC';
 
 -- Create custom functions for session management
 CREATE OR REPLACE FUNCTION update_updated_at_column()

--- a/backend/run_server.py
+++ b/backend/run_server.py
@@ -11,6 +11,7 @@ This server combines all the backend services:
 """
 
 from contextlib import asynccontextmanager
+import os
 
 import uvicorn
 
@@ -51,13 +52,14 @@ app = FastAPI(
 )
 
 # Add CORS middleware for frontend integration
+allow_origins = os.getenv(
+    "ALLOW_ORIGINS",
+    "http://localhost:3000,http://localhost:5173,https://yudai.app"
+).split(",")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000", 
-        "http://localhost:5173",  # React dev servers
-        "https://yudai.app",      # Production domain
-    ],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -13,7 +13,7 @@ while [ $attempt -lt $max_attempts ]; do
     echo "  Attempt $attempt/$max_attempts..."
     
     # Test database connectivity and readiness
-    if pg_isready -h db -p 5432 -U yudai_user -d yudai_db >/dev/null 2>&1; then
+    if pg_isready -h db -p 5432 -U yudai_user -d "$POSTGRES_DB" >/dev/null 2>&1; then
         echo "🎉 Database is ready!"
         break
     else

--- a/backend/test_db.py
+++ b/backend/test_db.py
@@ -15,10 +15,15 @@ from models import ChatSession, FileEmbedding, User
 from sqlalchemy import create_engine, inspect, text
 
 
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise ValueError("DATABASE_URL environment variable is required for tests")
+
+
 def test_database_connection():
     """Test basic database connection"""
     try:
-        engine = create_engine(os.getenv("DATABASE_URL", "postgresql://yudai_user:yudai_password@db:5432/yudai_db"))
+        engine = create_engine(DATABASE_URL)
         with engine.connect() as conn:
             result = conn.execute(text("SELECT 1"))
             print("✓ Database connection successful")
@@ -30,7 +35,7 @@ def test_database_connection():
 def test_table_structure():
     """Test that all required tables exist with correct structure"""
     try:
-        engine = create_engine(os.getenv("DATABASE_URL", "postgresql://yudai_user:yudai_password@db:5432/yudai_db"))
+        engine = create_engine(DATABASE_URL)
         inspector = inspect(engine)
         tables = inspector.get_table_names()
         
@@ -56,7 +61,7 @@ def test_table_structure():
 def test_file_embeddings_session_id():
     """Test that file_embeddings table has session_id column"""
     try:
-        engine = create_engine(os.getenv("DATABASE_URL", "postgresql://yudai_user:yudai_password@db:5432/yudai_db"))
+        engine = create_engine(DATABASE_URL)
         inspector = inspect(engine)
         
         # Get columns for file_embeddings table

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -71,6 +71,7 @@ services:
       - GITHUB_APP_PRIVATE_KEY_PATH=/app/yudaiv3.2025-08-02.private-key.pem
       - FRONTEND_BASE_URL=http://localhost:3000
       - GITHUB_REDIRECT_URI=http://localhost:3000/auth/callback
+      - ALLOW_ORIGINS=http://localhost:3000,http://localhost:5173
       - API_DOMAIN=localhost:8001
       - DEV_DOMAIN=localhost:3000
       - SECRET_KEY=dev-secret-key-change-in-production

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -101,6 +101,7 @@ services:
       - GITHUB_APP_PRIVATE_KEY_PATH=/app/yudaiv3.2025-08-02.private-key.pem
       - FRONTEND_BASE_URL=${FRONTEND_URL}
       - GITHUB_REDIRECT_URI=${GITHUB_REDIRECT_URI}
+      - ALLOW_ORIGINS=${FRONTEND_URL}
       - API_DOMAIN=${DOMAIN:-yudai.app}
       - DEV_DOMAIN=${DOMAIN:-yudai.app}
       - SECRET_KEY=${SECRET_KEY}

--- a/src/components/AuthSuccess.tsx
+++ b/src/components/AuthSuccess.tsx
@@ -49,7 +49,6 @@ export const AuthSuccess: React.FC = () => {
         await setAuthFromCallback({
           user,
           sessionToken,
-          githubToken: sessionToken, // Using session token as GitHub token for compatibility
         });
 
         console.log('[AuthSuccess] Authentication successful, redirecting to main app');

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -12,7 +12,6 @@ interface SessionState {
   // Auth state
   user: User | null;
   sessionToken: string | null;
-  githubToken: string | null;
   isAuthenticated: boolean;
   authLoading: boolean;
   authError: string | null;
@@ -47,7 +46,7 @@ interface SessionState {
   login: () => Promise<void>;
   logout: () => Promise<void>;
   refreshAuth: () => Promise<void>;
-  setAuthFromCallback: (authData: { user: User; sessionToken: string; githubToken: string }) => Promise<void>;
+  setAuthFromCallback: (authData: { user: User; sessionToken: string }) => Promise<void>;
   setAuthLoading: (loading: boolean) => void;
   setAuthError: (error: string | null) => void;
   
@@ -97,7 +96,6 @@ export const useSessionStore = create<SessionState>()(
         // Auth state
         user: null,
         sessionToken: null,
-        githubToken: null,
         isAuthenticated: false,
         authLoading: true,
         authError: null,
@@ -134,19 +132,15 @@ export const useSessionStore = create<SessionState>()(
             set({ authLoading: true, authError: null });
 
             // Check for stored session token in localStorage
-            console.log('[SessionStore] Checking localStorage for stored tokens');
+            console.log('[SessionStore] Checking localStorage for stored token');
             const storedSessionToken = localStorage.getItem('session_token');
-            const storedGithubToken = localStorage.getItem('github_token');
             console.log('[SessionStore] Stored session token:', storedSessionToken ? 'Found' : 'Not found');
-            console.log('[SessionStore] Stored GitHub token:', storedGithubToken ? 'Found' : 'Not found');
             
             if (storedSessionToken) {
               // No auth data in URL, check for stored session token
-              console.log('[SessionStore] No auth data in URL, checking localStorage for stored tokens');
+              console.log('[SessionStore] No auth data in URL, checking localStorage for stored token');
               const storedSessionToken = localStorage.getItem('session_token');
-              const storedGithubToken = localStorage.getItem('github_token');
               console.log('[SessionStore] Stored session token:', storedSessionToken ? 'Found' : 'Not found');
-              console.log('[SessionStore] Stored GitHub token:', storedGithubToken ? 'Found' : 'Not found');
               
               if (storedSessionToken) {
                 console.log('[SessionStore] Found stored session token, validating...');
@@ -166,7 +160,6 @@ export const useSessionStore = create<SessionState>()(
                   set({
                     user: user,
                     sessionToken: storedSessionToken,
-                    githubToken: storedGithubToken,
                     isAuthenticated: true,
                     authLoading: false,
                     authError: null,
@@ -181,7 +174,6 @@ export const useSessionStore = create<SessionState>()(
                     stack: error instanceof Error ? error.stack : undefined
                   });
                   localStorage.removeItem('session_token');
-                  localStorage.removeItem('github_token');
                   
                   // Clear any persisted session state since auth failed
                   get().clearSession();
@@ -189,7 +181,6 @@ export const useSessionStore = create<SessionState>()(
                   set({
                     user: null,
                     sessionToken: null,
-                    githubToken: null,
                     isAuthenticated: false,
                     authLoading: false,
                     authError: 'Stored session validation failed',
@@ -205,7 +196,6 @@ export const useSessionStore = create<SessionState>()(
                 set({
                   user: null,
                   sessionToken: null,
-                  githubToken: null,
                   isAuthenticated: false,
                   authLoading: false,
                   authError: null,
@@ -226,7 +216,6 @@ export const useSessionStore = create<SessionState>()(
             set({
               user: null,
               sessionToken: null,
-              githubToken: null,
               isAuthenticated: false,
               authLoading: false,
               authError: 'Auth initialization failed',
@@ -258,11 +247,9 @@ export const useSessionStore = create<SessionState>()(
           } finally {
             // Always clear local state and storage
             localStorage.removeItem('session_token');
-            localStorage.removeItem('github_token');
             set({
               user: null,
               sessionToken: null,
-              githubToken: null,
               isAuthenticated: false,
               authLoading: false,
               authError: null,
@@ -289,19 +276,17 @@ export const useSessionStore = create<SessionState>()(
           await get().initializeAuth();
         },
 
-        setAuthFromCallback: async (authData: { user: User; sessionToken: string; githubToken: string }) => {
+        setAuthFromCallback: async (authData: { user: User; sessionToken: string }) => {
           try {
             console.log('[SessionStore] Setting auth from callback:', authData);
             
             // Store session token in localStorage for persistence
-            localStorage.setItem('session_token', authData.sessionToken);
-            localStorage.setItem('github_token', authData.githubToken);
+              localStorage.setItem('session_token', authData.sessionToken);
             
             // Set the auth state
             set({
               user: authData.user,
               sessionToken: authData.sessionToken,
-              githubToken: authData.githubToken,
               isAuthenticated: true,
               authLoading: false,
               authError: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,6 @@ export interface User {
 export interface AuthState {
   user: User | null;
   sessionToken: string | null; // Changed from token to sessionToken
-  githubToken: string | null; // GitHub OAuth access token
   isAuthenticated: boolean;
   isLoading: boolean;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7,25 +7,6 @@
 // AUTH API TYPES
 // ============================================================================
 
-export interface CreateSessionRequest {
-  github_token: string;
-}
-
-export interface CreateSessionResponse {
-  session_token: string;
-  expires_at: string;
-  user: {
-    id: number;
-    github_username: string;
-    github_user_id: string;
-    email: string;
-    display_name: string;
-    avatar_url: string;
-    created_at: string;
-    last_login: string;
-  };
-}
-
 export interface ValidateSessionResponse {
   id: number;
   github_username: string;

--- a/src/utils/sessionErrorTest.ts
+++ b/src/utils/sessionErrorTest.ts
@@ -70,10 +70,7 @@ export const SessionErrorTests = {
     
     // Check localStorage
     const sessionToken = localStorage.getItem('session_token');
-    const githubToken = localStorage.getItem('github_token');
-    
     console.log('- Session token in localStorage:', sessionToken ? 'Found' : 'Not found');
-    console.log('- GitHub token in localStorage:', githubToken ? 'Found' : 'Not found');
     
     // Check if there's persisted Zustand state
     const persistedState = localStorage.getItem('session-storage');
@@ -101,7 +98,6 @@ export const SessionErrorTests = {
     console.log('🧪 [SessionTest] Clearing all session data');
     
     localStorage.removeItem('session_token');
-    localStorage.removeItem('github_token');
     localStorage.removeItem('session-storage');
     
     console.log('- All session data cleared');


### PR DESCRIPTION
## Summary
- use session token headers and drop unused GitHub token plumbing
- require DATABASE_URL env and parameterize CORS origins
- document and confine database names to compose files only

## Testing
- `npm test` (fails: No test files found)
- `pytest` (fails: TypeError: 'github_id' is an invalid keyword argument)


------
https://chatgpt.com/codex/tasks/task_e_68b211b8a7a48327b3831c236dbb8827