### PR TITLE
refactor(logger): route UI and hooks logging through shared logger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { useRepository } from './hooks/useRepository';
 import { useSessionManagement } from './hooks/useSessionManagement';
 import { useSession, useContextCards, useRemoveContextCard } from './hooks/useSessionQueries';
 import { useSessionStore } from './stores/sessionStore';
+import { logger } from './utils/logger';
 
 /**
  * Main App Content Component
@@ -67,7 +68,7 @@ function AppContent() {
 
   // Show repository selection after login if no repository is selected
   useEffect(() => {
-    console.log('Repository selection check:', {
+    logger.info('[App] Repository selection check:', {
       isAuthenticated,
       user: !!user,
       hasSelectedRepository
@@ -75,7 +76,7 @@ function AppContent() {
     
     // Always show repository selection after login if no repository is selected
     if (isAuthenticated && user && !hasSelectedRepository) {
-      console.log('Showing repository selection toast');
+      logger.info('[App] Showing repository selection toast');
       // Add a small delay to let the user see they've logged in
       const timer = setTimeout(() => {
         setShowRepositorySelection(true);
@@ -88,7 +89,7 @@ function AppContent() {
   // Session initialization check
   useEffect(() => {
     if (isAuthenticated && user && !activeSessionId && hasSelectedRepository) {
-      console.log('User is authenticated and has selected repository but no active session');
+      logger.info('[Session] User is authenticated and has selected repository but no active session');
       // Optionally auto-create a session or prompt user
       addToast('Ready to start a chat session!', 'info');
     }
@@ -97,7 +98,7 @@ function AppContent() {
   // Debug log session and data state
   useEffect(() => {
     if (activeSessionId) {
-      console.log('Session state:', {
+      logger.info('[Session] Session state:', {
         sessionId: activeSessionId,
         sessionData: sessionData ? 'loaded' : 'loading',
         contextCardsCount: contextCards.length,
@@ -138,7 +139,7 @@ function AppContent() {
       setShowRepositorySelection(false);
       addToast('Repository selected successfully!', 'success');
     } catch (error) {
-      console.error('Failed to select repository:', error);
+      logger.error('[Repository] Failed to select repository:', error);
       addToast('Failed to select repository', 'error');
     }
   };
@@ -263,7 +264,7 @@ function App() {
       localStorage.removeItem('session-storage');
       localStorage.removeItem('session_token');
     } catch (error) {
-      console.warn('[App] Failed to clear stored session data:', error);
+      logger.warn('[Session] Failed to clear stored session data:', error);
     }
 
     clearSession();
@@ -284,13 +285,13 @@ function App() {
 
   // Handle session errors by clearing session and optionally logging out
   const handleSessionError = () => {
-    console.log('[App] Handling session error - clearing session state');
+    logger.info('[Session] Handling session error - clearing session state');
     clearSession();
   };
 
   // Handle retry by re-initializing auth
   const handleRetry = () => {
-    console.log('[App] Retrying after error - redirecting to login');
+    logger.info('[Auth] Retrying after error - redirecting to login');
     window.location.href = '/auth/login';
   };
 

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { logger } from '../utils/logger';
 
 /**
  * AuthCallback component handles OAuth error callbacks from the backend
@@ -19,7 +20,7 @@ export const AuthCallback: React.FC = () => {
     const searchParams = new URLSearchParams(window.location.search);
     const error = searchParams.get('error');
     if (error) {
-      console.error('[AuthCallback] OAuth error received:', error);
+      logger.error('[Auth] OAuth error received:', error);
       // Redirect to login page with the error
       navigate(`/auth/login?error=${encodeURIComponent(error)}`, { replace: true });
     } else {

--- a/src/components/AuthSuccess.tsx
+++ b/src/components/AuthSuccess.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useSessionStore } from '../stores/sessionStore';
+import { logger } from '../utils/logger';
 
 /**
  * AuthSuccess component handles the OAuth callback from GitHub
@@ -22,7 +23,7 @@ export const AuthSuccess: React.FC = () => {
 
     const handleAuthSuccess = async () => {
       try {
-        console.log('[AuthSuccess] Processing OAuth callback data');
+        logger.info('[Auth] Processing OAuth callback data');
 
         const searchParams = new URLSearchParams(window.location.search);
 
@@ -36,7 +37,7 @@ export const AuthSuccess: React.FC = () => {
         const githubId = searchParams.get('github_id');
 
         if (!sessionToken || !userId || !username) {
-          console.error('[AuthSuccess] Missing required auth parameters');
+          logger.error('[Auth] Missing required auth parameters');
           navigate('/auth/login?error=missing_auth_data');
           return;
         }
@@ -53,7 +54,7 @@ export const AuthSuccess: React.FC = () => {
           last_login: new Date().toISOString(),
         };
 
-        console.log('[AuthSuccess] Setting up user session:', user);
+        logger.info('[Auth] Setting up user session:', user);
 
         // Set up the session using the session store
         setAuthFromCallback({
@@ -63,13 +64,13 @@ export const AuthSuccess: React.FC = () => {
 
         clearSession();
 
-        console.log('[AuthSuccess] Authentication successful, redirecting to main app');
+        logger.info('[Auth] Authentication successful, redirecting to main app');
         
         // Redirect to the main application
         navigate('/', { replace: true });
 
       } catch (error) {
-        console.error('[AuthSuccess] Error processing auth callback:', error);
+        logger.error('[Auth] Error processing auth callback:', error);
         navigate('/auth/login?error=auth_processing_failed');
       }
     };

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -22,6 +22,7 @@ import { useRepository } from '../hooks/useRepository';
 import { useSessionStore } from '../stores/sessionStore';
 import { useAuthStore } from '../stores/authStore';
 import { API, buildApiUrl } from '../config/api';
+import { logger } from '../utils/logger';
 
 // Types are now imported from '../types'
 
@@ -234,11 +235,11 @@ export const Chat: React.FC<ChatProps> = ({
   }, [fileContext, messages]);
 
   const showError = useCallback((message: string) => {
-    console.error('[Chat] Error occurred:', message);
+    logger.error('[Chat] Error occurred:', message);
     if (onShowError) {
       onShowError(message);
     } else {
-      console.error('Chat Error:', message);
+      logger.error('[Chat] Chat error:', message);
     }
   }, [onShowError]);
 
@@ -287,7 +288,7 @@ export const Chat: React.FC<ChatProps> = ({
           );
 
           if (response) {
-              console.log('[Chat] Message sent successfully:', response.message_id);
+              logger.info('[Chat] Message sent successfully:', response.message_id);
 
               // Invalidate and refetch the messages to show the updated conversation
               await queryClient.invalidateQueries({
@@ -296,7 +297,7 @@ export const Chat: React.FC<ChatProps> = ({
           }
 
       } catch (error) {
-          console.error('[Chat] Message sending failed:', error);
+          logger.error('[Chat] Message sending failed:', error);
           showError('Failed to send message. Please try again.');
       } finally {
           setIsLoading(false);
@@ -328,7 +329,7 @@ export const Chat: React.FC<ChatProps> = ({
           timestamp: msg.timestamp.toISOString()
         }));
 
-      console.log('[Chat] Prepared conversation messages:', conversationMessages);
+      logger.info('[Chat] Prepared conversation messages:', conversationMessages);
 
       // Convert file context to FileContextItem format
       const fileContextItems: FileContextItem[] = fileContext.map((file) => ({
@@ -373,7 +374,7 @@ export const Chat: React.FC<ChatProps> = ({
       }
 
     } catch (error) {
-      console.error('[Chat] Issue creation failed:', error);
+      logger.error('[Chat] Issue creation failed:', error);
       const errorText = `Failed to create GitHub issue: ${error instanceof Error ? error.message : 'Unknown error'}`;
       showError(errorText);
     } finally {
@@ -392,7 +393,7 @@ export const Chat: React.FC<ChatProps> = ({
         const result = await createGitHubIssueMutation.mutateAsync(currentIssuePreview.userIssue.issue_id);
 
         if (result?.success && result?.github_url) {
-          console.log('[Chat] GitHub issue created successfully:', result.github_url);
+          logger.info('[Chat] GitHub issue created successfully:', result.github_url);
           setShowIssuePreview(false);
           setCurrentIssuePreview(null);
           showError(`✓ GitHub issue created successfully! ${result.github_url}`);
@@ -401,7 +402,7 @@ export const Chat: React.FC<ChatProps> = ({
         }
       }
     } catch (error) {
-      console.error('[Chat] Failed to create GitHub issue:', error);
+      logger.error('[Chat] Failed to create GitHub issue:', error);
       showError(`Failed to create GitHub issue: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }, [currentIssuePreview, showError, createGitHubIssueMutation]);
@@ -421,7 +422,7 @@ export const Chat: React.FC<ChatProps> = ({
     }
 
     try {
-      console.log('[Chat] Starting solver for issue:', issueId);
+      logger.info('[Chat] Starting solver for issue:', issueId);
 
       // Close the preview modal
       setShowIssuePreview(false);
@@ -446,7 +447,7 @@ export const Chat: React.FC<ChatProps> = ({
       }
 
       const result = await response.json();
-      console.log('[Chat] Solver started successfully:', result);
+      logger.info('[Chat] Solver started successfully:', result);
 
       // Invalidate messages to show solver status updates
       await queryClient.invalidateQueries({
@@ -457,7 +458,7 @@ export const Chat: React.FC<ChatProps> = ({
       showError(`🚀 AI Solver started! Session ID: ${result.solve_session_id}. Watch the chat for progress updates.`);
 
     } catch (error) {
-      console.error('[Chat] Failed to start solver:', error);
+      logger.error('[Chat] Failed to start solver:', error);
       showError(`Failed to start solver: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }, [selectedRepository, activeSessionId, currentIssuePreview, sessionToken, showError, queryClient]);

--- a/src/components/ContextCards.tsx
+++ b/src/components/ContextCards.tsx
@@ -11,6 +11,7 @@ import type {
 import { useRepository } from '../hooks/useRepository';
 import { useCreateIssueWithContext } from '../hooks/useSessionQueries';
 import { useSessionStore } from '../stores/sessionStore';
+import { logger } from '../utils/logger';
 
 interface IssuePreviewData extends GitHubIssuePreview {
   userIssue?: UserIssueResponse;
@@ -58,14 +59,14 @@ export const ContextCards: React.FC<ContextCardsProps> = ({
     if (onShowError) {
       onShowError(message);
     } else {
-      console.error('ContextCards Error:', message);
+      logger.error('[Context] Error:', message);
     }
   }, [onShowError]);
 
   // Load context cards when session changes (cards are now passed as props from parent)
   useEffect(() => {
     if (activeSessionId && cards.length === 0) {
-      console.log('Context cards available:', cards.length);
+      logger.info('[Context] Context cards available:', cards.length);
     }
   }, [activeSessionId, cards]);
 
@@ -73,13 +74,13 @@ export const ContextCards: React.FC<ContextCardsProps> = ({
     if (!activeSessionId) return;
 
     try {
-      console.log('Removing context card:', cardId);
+      logger.info('[Context] Removing context card:', cardId);
       await deleteContextCard(cardId);
-      console.log('Context card removed successfully');
+      logger.info('[Context] Context card removed successfully');
       // Call the onRemoveCard callback to update the parent state
       onRemoveCard(cardId);
     } catch (error) {
-      console.error('Failed to remove context card:', error);
+      logger.error('[Context] Failed to remove context card:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to remove context card';
       showError(`Failed to remove context card: ${errorMessage}`);
     }
@@ -165,7 +166,7 @@ export const ContextCards: React.FC<ContextCardsProps> = ({
         onShowIssuePreview(previewData);
       }
     } catch (error) {
-      console.error('Failed to create issue with context:', error);
+      logger.error('[Context] Failed to create issue with context:', error);
       showError('Failed to create issue with context. Please try again.');
     } finally {
       setIsLoading(false);

--- a/src/components/DiffModal.tsx
+++ b/src/components/DiffModal.tsx
@@ -3,6 +3,7 @@ import { X, ExternalLink, GitBranch, FileText, MessageSquare, Tag, Clock, Check 
 import type { GitHubIssuePreview, ChatContextMessage, FileContextItem } from '../types/api';
 import { UserIssueResponse } from '../types';
 import { useSessionStore } from '../stores/sessionStore';
+import { logger } from '../utils/logger';
 
 interface IssuePreviewData extends GitHubIssuePreview {
   userIssue?: UserIssueResponse;
@@ -63,7 +64,7 @@ export const DiffModal: React.FC<DiffModalProps> = ({
       }
 
     } catch (error) {
-      console.error('Failed to create GitHub issue:', error);
+      logger.error('[DiffModal] Failed to create GitHub issue:', error);
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
       showError(`Failed to create GitHub issue: ${errorMessage}`);
     } finally {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw, Wifi } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import { logger } from '../utils/logger';
 
 interface Props {
   children: ReactNode;
@@ -46,7 +47,7 @@ class ErrorBoundaryClass extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    logger.error('[ErrorBoundary] Caught an error:', error, errorInfo);
     this.setState({ errorInfo });
   }
 
@@ -179,11 +180,11 @@ export const ErrorBoundary: React.FC<ErrorBoundaryWrapperProps> = ({
 
   const handleReauth = async () => {
     try {
-      console.log('[ErrorBoundary] Attempting to re-authenticate user');
+      logger.info('[Auth] Attempting to re-authenticate user');
       await logout(); // Clear current session state
       await login();  // Redirect to login through session store
     } catch (error) {
-      console.error('[ErrorBoundary] Re-authentication failed:', error);
+      logger.error('[Auth] Re-authentication failed:', error);
       // Fallback to direct redirect if session store login fails
       window.location.href = '/auth/login';
     }

--- a/src/components/FileDependencies.tsx
+++ b/src/components/FileDependencies.tsx
@@ -7,6 +7,7 @@ import {
   useFileDependencies,
   useAddContextCard
 } from '../hooks/useSessionQueries';
+import { logger } from '../utils/logger';
 // react-query not needed here currently
 
 interface FileDependenciesProps {
@@ -36,7 +37,7 @@ export const FileDependencies: React.FC<FileDependenciesProps> = ({
   }, [onShowError]);
 
   const handleRefresh = async () => {
-    console.log('[FileDependencies] Refreshing file dependencies...');
+    logger.info('[FileDependencies] Refreshing file dependencies...');
     refetch();
   };
 

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
+import { logger } from '../utils/logger';
 
 /**
  * LoginPage component handles GitHub OAuth login
@@ -31,12 +32,12 @@ export const LoginPage: React.FC = () => {
     try {
       setError(null);
 
-      console.log('[LoginPage] Initiating GitHub OAuth login');
+      logger.info('[Auth] Initiating GitHub OAuth login');
 
       await login();
 
     } catch (error) {
-      console.error('[LoginPage] Login failed:', error);
+      logger.error('[Auth] Login failed:', error);
       setError('Failed to initiate login. Please try again.');
     }
   };

--- a/src/components/RepositorySelectionToast.tsx
+++ b/src/components/RepositorySelectionToast.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ChevronDown, Github, GitBranch, Check, X, Loader2 } from 'lucide-react';
 import { GitHubRepository, GitHubBranch, SelectedRepository } from '../types';
 import { useSessionStore } from '../stores/sessionStore';
+import { logger } from '../utils/logger';
 
 interface RepositorySelectionToastProps {
   isOpen: boolean;
@@ -36,7 +37,7 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
   // Load repositories when toast opens
   useEffect(() => {
     if (isOpen && availableRepositories.length === 0) {
-      console.log('Loading repositories...');
+      logger.info('[Repository] Loading repositories...');
       const loadRepos = async () => {
         setRepositoryLoading(true);
         setError(null);
@@ -44,9 +45,9 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
         try {
           const { loadRepositories: loadReposFromStore } = useSessionStore.getState();
           await loadReposFromStore();
-          console.log('Repositories loaded successfully via sessionStore');
+          logger.info('[Repository] Repositories loaded successfully via session store');
         } catch (error) {
-          console.error('Failed to load repositories:', error);
+          logger.error('[Repository] Failed to load repositories:', error);
           setError('Failed to load repositories. Please try again.');
         } finally {
           setRepositoryLoading(false);
@@ -60,7 +61,7 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
   useEffect(() => {
     if (!selectedRepoFullName) return;
 
-    console.log('Loading branches for repository:', selectedRepoFullName);
+    logger.info('[Repository] Loading branches for repository:', selectedRepoFullName);
     const loadBranchesForRepo = async () => {
       setLoadingBranches(true);
       setSelectedBranch('');
@@ -68,9 +69,9 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
 
       try {
         const [owner, repo] = selectedRepoFullName.split('/');
-        console.log('Fetching branches for:', { owner, repo });
+        logger.info('[Repository] Fetching branches for:', { owner, repo });
         const branchList = await loadRepositoryBranches(owner, repo);
-        console.log('Received branch list:', branchList);
+        logger.info('[Repository] Received branch list:', branchList);
 
         // Transform API response to match frontend GitHubBranch type
         const transformedBranches: GitHubBranch[] = branchList.map(branch => ({
@@ -79,7 +80,7 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
           protected: false // API doesn't provide this, set default
         }));
 
-        console.log('Transformed branches:', transformedBranches);
+        logger.info('[Repository] Transformed branches:', transformedBranches);
         setBranches(transformedBranches);
 
         // Auto-select main or master branch if available, or default branch
@@ -87,14 +88,14 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
           b.name === 'main' || b.name === 'master' || b.name === selectedRepoDefaultBranch
         ));
         if (defaultBranch) {
-          console.log('Auto-selecting default branch:', defaultBranch.name);
+          logger.info('[Repository] Auto-selecting default branch:', defaultBranch.name);
           setSelectedBranch(defaultBranch.name);
         } else if (transformedBranches.length > 0) {
-          console.log('Auto-selecting first branch:', transformedBranches[0].name);
+          logger.info('[Repository] Auto-selecting first branch:', transformedBranches[0].name);
           setSelectedBranch(transformedBranches[0].name);
         }
       } catch (error) {
-        console.error('Failed to load branches:', error);
+        logger.error('[Repository] Failed to load branches:', error);
         setError('Failed to load branches. Please try again.');
       } finally {
         setLoadingBranches(false);
@@ -107,14 +108,14 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
   // Set error from repository context
   useEffect(() => {
     if (repositoryError) {
-      console.log('Repository error:', repositoryError);
+      logger.warn('[Repository] Repository error:', repositoryError);
       setError(repositoryError);
     }
   }, [repositoryError]);
 
   const handleConfirm = () => {
     if (selectedRepository && selectedBranch) {
-      console.log('Confirming selection:', {
+      logger.info('[Repository] Confirming selection:', {
         repository: selectedRepository.full_name,
         branch: selectedBranch
       });
@@ -126,13 +127,13 @@ export const RepositorySelectionToast: React.FC<RepositorySelectionToastProps> =
   };
 
   const handleRepositorySelect = (repo: GitHubRepository) => {
-    console.log('Repository selected:', repo.full_name);
+    logger.info('[Repository] Repository selected:', repo.full_name);
     setSelectedRepository(repo);
     setIsRepoDropdownOpen(false);
   };
 
   const handleBranchSelect = (branchName: string) => {
-    console.log('Branch selected:', branchName);
+    logger.info('[Repository] Branch selected:', branchName);
     setSelectedBranch(branchName);
     setIsBranchDropdownOpen(false);
   };

--- a/src/components/SessionErrorBoundary.tsx
+++ b/src/components/SessionErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw, Home } from 'lucide-react';
+import { logger } from '../utils/logger';
 
 interface SessionErrorBoundaryProps {
   children: ReactNode;
@@ -47,7 +48,7 @@ export class SessionErrorBoundary extends Component<SessionErrorBoundaryProps, S
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error('[SessionErrorBoundary] Caught error:', error, errorInfo);
+    logger.error('[Session] Caught error:', error, errorInfo);
     
     this.setState({
       error,
@@ -63,7 +64,7 @@ export class SessionErrorBoundary extends Component<SessionErrorBoundaryProps, S
   handleRetry = () => {
     if (this.retryCount < this.maxRetries) {
       this.retryCount++;
-      console.log(`[SessionErrorBoundary] Retry attempt ${this.retryCount}/${this.maxRetries}`);
+      logger.info(`[Session] Retry attempt ${this.retryCount}/${this.maxRetries}`);
       
       this.setState({
         hasError: false,

--- a/src/components/SolveIssues.tsx
+++ b/src/components/SolveIssues.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useRepository } from '../hooks/useRepository';
 import { useSessionManagement } from '../hooks/useSessionManagement';
 import { useAuthStore } from '../stores/authStore';
+import { logger } from '../utils/logger';
 import type {
   SolveStatusResponse,
   StartSolveRequest,
@@ -465,7 +466,7 @@ export function SolveIssues() {
         );
         setIssues(data);
       } catch (err) {
-        console.error('Failed to fetch issues:', err);
+        logger.error('[SolveIssues] Failed to fetch issues:', err);
         const error = err as Error;
         setError(error.message || 'Failed to fetch issues');
       } finally {
@@ -483,7 +484,7 @@ export function SolveIssues() {
         const data = await apiCall('/api/daifu/ai-models');
         setAvailableModels(data);
       } catch (err) {
-        console.error('Failed to fetch AI models:', err);
+        logger.error('[SolveIssues] Failed to fetch AI models:', err);
       }
     };
 
@@ -506,7 +507,7 @@ export function SolveIssues() {
           setActiveSolveId(null);
         }
       } catch (err) {
-        console.error('Failed to fetch solve status:', err);
+        logger.error('[SolveIssues] Failed to fetch solve status:', err);
       }
     };
 
@@ -569,7 +570,7 @@ export function SolveIssues() {
       });
       setSelectedIssue(null);
     } catch (err) {
-      console.error('Failed to start solve:', err);
+      logger.error('[SolveIssues] Failed to start solve:', err);
       const error = err as Error;
       setError(error.message || 'Failed to start solve');
     } finally {
@@ -590,7 +591,7 @@ export function SolveIssues() {
       setActiveSolveId(null);
       setSolveStatus(null);
     } catch (err) {
-      console.error('Failed to cancel solve:', err);
+      logger.error('[SolveIssues] Failed to cancel solve:', err);
     }
   };
 

--- a/src/components/TrajectoryViewer.tsx
+++ b/src/components/TrajectoryViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { FileText, ChevronRight, ChevronDown, DollarSign, MessageSquare, Clock, CheckCircle, XCircle, AlertCircle } from 'lucide-react';
 import trajectoryData from '../data/last_mini_run.traj.json';
+import { logger } from '../utils/logger';
 
 interface TrajectoryMessage {
   role: string;
@@ -50,7 +51,7 @@ export const TrajectoryViewer: React.FC<TrajectoryViewerProps> = ({ sessionId })
       // This is more reliable than fetching from public directory
       setTrajectory(trajectoryData as TrajectoryData);
     } catch (err) {
-      console.error('Failed to load trajectory:', err);
+      logger.error('[Trajectory] Failed to load trajectory:', err);
       setError(err instanceof Error ? err.message : 'Failed to load trajectory');
     } finally {
       setLoading(false);
@@ -251,4 +252,3 @@ export const TrajectoryViewer: React.FC<TrajectoryViewerProps> = ({ sessionId })
     </div>
   );
 };
-

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { User, LogOut, ChevronDown, Github, GitBranch } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { useRepository } from '../hooks/useRepository';
+import { logger } from '../utils/logger';
 
 export const UserProfile: React.FC = () => {
   const { user, logout, isLoading } = useAuth();
@@ -14,7 +15,7 @@ export const UserProfile: React.FC = () => {
       setIsLoggingOut(true);
       await logout();
     } catch (error) {
-      console.error('Logout failed:', error);
+      logger.error('[Auth] Logout failed:', error);
       setIsLoggingOut(false);
     }
   };

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useAuthStore } from '../stores/authStore';
+import { logger } from '../utils/logger';
 
 /**
  * Custom hook to access authentication state from the auth store
@@ -34,7 +35,7 @@ export const useAuth = () => {
 
   // Debug logging for auth state changes
   useEffect(() => {
-    console.log('[useAuth] Auth state from auth store:', {
+    logger.info('[Auth] Auth state from auth store:', {
       isAuthenticated,
       isLoading,
       hasUser: !!user,

--- a/src/hooks/useSessionQueries.ts
+++ b/src/hooks/useSessionQueries.ts
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSessionStore } from '../stores/sessionStore';
 import { useAuthStore } from '../stores/authStore';
 import { API, buildApiUrl } from '../config/api';
+import { logger } from '../utils/logger';
 import {
   ChatMessage,
   ContextCard,
@@ -45,7 +46,7 @@ const isSessionNotFoundError = (error: unknown): boolean => {
 // Helper function to handle session errors by clearing invalid session
 const handleSessionError = (error: unknown, sessionId: string, clearSession: () => void) => {
   if (isSessionNotFoundError(error)) {
-    console.warn(`[useSessionQueries] Session ${sessionId} not found, clearing invalid session`);
+    logger.warn(`[Session] Session ${sessionId} not found, clearing invalid session`);
     clearSession();
     return true; // Indicates session was cleared
   }
@@ -62,7 +63,7 @@ const shouldAllowSessionRequest = (sessionId: string): boolean => {
   const timeSinceLastRequest = now - lastRequestTime;
   
   if (timeSinceLastRequest < SESSION_REQUEST_COOLDOWN) {
-    console.log(`[SessionQueries] Rate limiting session request for ${sessionId}, last request was ${timeSinceLastRequest}ms ago`);
+    logger.info(`[Session] Rate limiting session request for ${sessionId}, last request was ${timeSinceLastRequest}ms ago`);
     return false;
   }
   

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,14 +6,18 @@ export enum LogLevel {
   ERROR = 'error'
 }
 
+const isDevelopment = import.meta.env.MODE === 'development';
+
 export const logger = {
   debug: (message: string, ...args: unknown[]) => {
-    if (process.env.NODE_ENV === 'development') {
+    if (isDevelopment) {
       console.log(`[DEBUG] ${message}`, ...args);
     }
   },
   info: (message: string, ...args: unknown[]) => {
-    console.log(`[INFO] ${message}`, ...args);
+    if (isDevelopment) {
+      console.log(`[INFO] ${message}`, ...args);
+    }
   },
   warn: (message: string, ...args: unknown[]) => {
     console.warn(`[WARN] ${message}`, ...args);


### PR DESCRIPTION
### Motivation
- Centralize logging and make verbose output controllable by environment to avoid noisy logs in production.
- Standardize log message prefixes (e.g., `[Auth]`, `[Session]`, `[Chat]`) so logs are easier to filter and correlate.
- Replace ad-hoc `console.*` calls in UI components and hooks with a single `logger` utility to enable consistent behavior and future enhancements.

### Description
- Updated `src/utils/logger.ts` to use `const isDevelopment = import.meta.env.MODE === 'development'` and to gate `debug`/`info` output behind development mode while leaving `warn`/`error` always enabled, and exported `logger` with `debug|info|warn|error` methods.
- Replaced direct `console.log`/`console.warn`/`console.error` usages across UI components and hooks with calls to `logger` and added standardized prefixes such as `[Auth]`, `[Session]`, `[Chat]`, `[Repository]`, `[Context]`, and `[DiffModal]` for consistent filtering (notable files changed include `src/App.tsx`, `src/components/Chat.tsx`, `src/components/ContextCards.tsx`, `src/components/RepositorySelectionToast.tsx`, `src/components/AuthSuccess.tsx`, `src/components/AuthCallback.tsx`, `src/components/LoginPage.tsx`, `src/components/DiffModal.tsx`, `src/components/ErrorBoundary.tsx`, `src/components/SessionErrorBoundary.tsx`, `src/components/TrajectoryViewer.tsx`, `src/components/FileDependencies.tsx`, `src/components/SolveIssues.tsx`, `src/components/UserProfile.tsx`, `src/hooks/useAuth.tsx`, `src/hooks/useSessionManagement.ts`, `src/hooks/useSessionQueries.ts`).
- Kept `warn`/`error` behavior unchanged (always emitted) and ensured debug/info messages only appear in development builds to reduce production noise.

### Testing
- Automated tests: none executed for this change (no test run was requested during the refactor).
- Manual checks performed during the rollout: compiled and committed the changes and verified source replacements via repository diffs (no runtime test harness or CI run was executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abfb5826083278f1e7db66b294490)