### PR TITLE
feat: Modal provisioning + controller proxy + WS-only protocol

### DIFF
--- a/backend/config/realtime_flags.py
+++ b/backend/config/realtime_flags.py
@@ -23,6 +23,9 @@ class RealtimeFeatureFlags:
     tunnel_mode_enabled: bool
     ws_chat_enabled: bool
     sse_stream_enabled: bool
+    modal_provisioning_enabled: bool
+    controller_proxy_enabled: bool
+    ws_unified_enabled: bool
     contract_version: str
 
     @classmethod
@@ -36,6 +39,13 @@ class RealtimeFeatureFlags:
             tunnel_mode_enabled=_env_bool("REALTIME_TUNNEL_MODE_ENABLED", False),
             ws_chat_enabled=_env_bool("REALTIME_WS_CHAT_ENABLED", False),
             sse_stream_enabled=_env_bool("REALTIME_SSE_STREAM_ENABLED", False),
+            modal_provisioning_enabled=_env_bool(
+                "REALTIME_MODAL_PROVISIONING_ENABLED", False
+            ),
+            controller_proxy_enabled=_env_bool(
+                "REALTIME_CONTROLLER_PROXY_ENABLED", False
+            ),
+            ws_unified_enabled=_env_bool("REALTIME_WS_UNIFIED_ENABLED", False),
             contract_version=normalized_contract_version,
         )
 
@@ -45,6 +55,9 @@ class RealtimeFeatureFlags:
             "tunnel_mode_enabled": self.tunnel_mode_enabled,
             "ws_chat_enabled": self.ws_chat_enabled,
             "sse_stream_enabled": self.sse_stream_enabled,
+            "modal_provisioning_enabled": self.modal_provisioning_enabled,
+            "controller_proxy_enabled": self.controller_proxy_enabled,
+            "ws_unified_enabled": self.ws_unified_enabled,
             "contract_version": self.contract_version,
         }
 

--- a/backend/realtime/controller_routes.py
+++ b/backend/realtime/controller_routes.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Optional
 
-from auth.github_oauth import get_current_user
+import httpx
+from auth.github_oauth import get_current_user, validate_session_token
+from config.realtime_flags import get_realtime_feature_flags
 from db.database import get_db
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
-from models import ChatSession, SessionRuntime, User
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, WebSocket, status
+from models import ChatSession, Sandbox, SandboxStatus, SessionRuntime, User
 from sqlalchemy.orm import Session
 
+from .errors import RealtimeErrorCode, as_http_exception
 from .lifecycle import get_realtime_lifecycle_service
 from .schemas import (
     CleanupResponse,
@@ -22,7 +26,15 @@ from .schemas import (
     TunnelResolveResponse,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["realtime-controller"])
+
+# Hop-by-hop headers that must not be forwarded through a proxy
+_HOP_BY_HOP_HEADERS = frozenset({
+    "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+    "te", "trailers", "transfer-encoding", "upgrade",
+})
 
 
 
@@ -41,13 +53,15 @@ def _to_sandbox_response(sandbox) -> SandboxResponse:
 
 def _to_runtime_response(runtime: SessionRuntime) -> RuntimeResponse:
     metadata = runtime.runtime_metadata if isinstance(runtime.runtime_metadata, dict) else {}
+    flags = get_realtime_feature_flags()
     return RuntimeResponse(
         runtime_id=runtime.runtime_id,
         sandbox_id=runtime.sandbox_id or "",
         identity_key=(metadata.get("identity_key") if isinstance(metadata, dict) else "")
         or "",
         status=runtime.status,
-        tunnel_url=runtime.tunnel_url,
+        tunnel_url=None if flags.controller_proxy_enabled else runtime.tunnel_url,
+        proxy_base_url=f"/api/controller/proxy/sessions/" if flags.controller_proxy_enabled else None,
         token_ttl_seconds=3600,
         tunnel_expires_at=runtime.tunnel_expires_at,
         completion_issue_created=runtime.completion_issue_created,
@@ -62,7 +76,7 @@ def _to_runtime_response(runtime: SessionRuntime) -> RuntimeResponse:
     response_model=SandboxResponse,
     status_code=status.HTTP_201_CREATED,
 )
-def create_sandbox(
+async def create_sandbox(
     request: SandboxCreateRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -98,7 +112,7 @@ def create_sandbox(
             detail="Session not found for sandbox provisioning",
         )
 
-    envelope = lifecycle.create_runtime_for_session(
+    envelope = await lifecycle.create_runtime_for_session(
         db,
         session=session_obj,
         user_id=current_user.id,
@@ -221,7 +235,7 @@ def cleanup_sandboxes(
     response_model=RuntimeResponse,
     status_code=status.HTTP_201_CREATED,
 )
-def ensure_runtime_for_session(
+async def ensure_runtime_for_session(
     session_id: str,
     request: RuntimeEnsureRequest,
     db: Session = Depends(get_db),
@@ -240,7 +254,7 @@ def ensure_runtime_for_session(
     if not session_obj:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
 
-    envelope = lifecycle.create_runtime_for_session(
+    envelope = await lifecycle.create_runtime_for_session(
         db,
         session=session_obj,
         user_id=current_user.id,
@@ -295,3 +309,160 @@ def get_runtime_for_session(
         response.identity_key = sandbox.identity_key
         response.token_ttl_seconds = sandbox.tunnel_token_ttl_seconds or 3600
     return response
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve sandbox tunnel_url for a session
+# ---------------------------------------------------------------------------
+
+
+def _resolve_sandbox_tunnel(db: Session, session_id: str) -> str:
+    """Look up the tunnel_url for a session's active sandbox. Raises on failure."""
+    session_obj = (
+        db.query(ChatSession)
+        .filter(ChatSession.session_id == session_id)
+        .first()
+    )
+    if not session_obj:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+
+    lifecycle = get_realtime_lifecycle_service()
+    runtime = lifecycle._get_latest_runtime(db, session_id=session_obj.id)
+    if not runtime or not runtime.sandbox_id:
+        raise as_http_exception(RealtimeErrorCode.TUNNEL_UNAVAILABLE)
+
+    sandbox = db.query(Sandbox).filter(Sandbox.id == runtime.sandbox_id).first()
+    if not sandbox:
+        raise as_http_exception(RealtimeErrorCode.TUNNEL_UNAVAILABLE)
+    if sandbox.status == SandboxStatus.TERMINATED.value:
+        raise as_http_exception(RealtimeErrorCode.TUNNEL_TERMINATED)
+    if not sandbox.tunnel_url:
+        raise as_http_exception(RealtimeErrorCode.TUNNEL_UNAVAILABLE)
+
+    return sandbox.tunnel_url
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: HTTP reverse proxy
+# ---------------------------------------------------------------------------
+
+
+@router.api_route(
+    "/controller/proxy/sessions/{session_id}/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
+)
+async def proxy_http(
+    request: Request,
+    session_id: str,
+    path: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    """Reverse-proxy HTTP requests to the sandbox tunnel (same origin, no CORS)."""
+    tunnel_url = _resolve_sandbox_tunnel(db, session_id)
+
+    upstream_url = f"{tunnel_url.rstrip('/')}/{path}"
+    if request.url.query:
+        upstream_url = f"{upstream_url}?{request.url.query}"
+
+    # Forward headers, stripping hop-by-hop
+    forward_headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in _HOP_BY_HOP_HEADERS and k.lower() != "host"
+    }
+
+    body = await request.body()
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            upstream_resp = await client.request(
+                method=request.method,
+                url=upstream_url,
+                headers=forward_headers,
+                content=body,
+            )
+    except httpx.ConnectError:
+        raise as_http_exception(RealtimeErrorCode.PROXY_UPSTREAM_ERROR, detail="Sandbox unreachable")
+
+    # Forward response headers, stripping hop-by-hop
+    resp_headers = {
+        k: v
+        for k, v in upstream_resp.headers.items()
+        if k.lower() not in _HOP_BY_HOP_HEADERS
+    }
+
+    return Response(
+        content=upstream_resp.content,
+        status_code=upstream_resp.status_code,
+        headers=resp_headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: WebSocket reverse proxy
+# ---------------------------------------------------------------------------
+
+
+@router.websocket("/controller/proxy/sessions/{session_id}/ws/{path:path}")
+async def proxy_websocket(
+    websocket: WebSocket,
+    session_id: str,
+    path: str,
+    token: str = Query(...),
+    db: Session = Depends(get_db),
+) -> None:
+    """Bidirectional WebSocket relay between client and sandbox."""
+    import websockets
+
+    user = validate_session_token(db, token)
+    if not user:
+        await websocket.close(code=4401, reason="invalid_session_token")
+        return
+
+    tunnel_url = _resolve_sandbox_tunnel(db, session_id)
+    # Convert http(s) to ws(s)
+    ws_upstream_url = tunnel_url.rstrip("/").replace("https://", "wss://").replace("http://", "ws://")
+    ws_upstream_url = f"{ws_upstream_url}/{path}?token={token}"
+
+    await websocket.accept()
+
+    try:
+        async with websockets.connect(ws_upstream_url) as upstream_ws:
+
+            async def client_to_upstream() -> None:
+                try:
+                    while True:
+                        data = await websocket.receive_text()
+                        await upstream_ws.send(data)
+                except Exception:
+                    pass
+
+            async def upstream_to_client() -> None:
+                try:
+                    async for msg in upstream_ws:
+                        if isinstance(msg, str):
+                            await websocket.send_text(msg)
+                        else:
+                            await websocket.send_bytes(msg)
+                except Exception:
+                    pass
+
+            import asyncio
+            done, pending = await asyncio.wait(
+                [
+                    asyncio.create_task(client_to_upstream()),
+                    asyncio.create_task(upstream_to_client()),
+                ],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+
+    except Exception as e:
+        logger.warning("WS proxy error for session %s: %s", session_id, e)
+    finally:
+        try:
+            await websocket.close()
+        except Exception:
+            pass

--- a/backend/realtime/errors.py
+++ b/backend/realtime/errors.py
@@ -14,12 +14,18 @@ class RealtimeErrorCode(str, Enum):
     TUNNEL_AUTH_EXPIRED = "TUNNEL_AUTH_EXPIRED"
     TUNNEL_TERMINATED = "TUNNEL_TERMINATED"
     TUNNEL_RESOLVE_FAILED = "TUNNEL_RESOLVE_FAILED"
+    # Deprecated: SSE codes superseded by WS unified protocol
     SSE_AUTH_INVALID = "SSE_AUTH_INVALID"
     SSE_STREAM_TIMEOUT = "SSE_STREAM_TIMEOUT"
     SSE_STREAM_TERMINATED = "SSE_STREAM_TERMINATED"
     WS_AUTH_INVALID = "WS_AUTH_INVALID"
     WS_RETRY_EXHAUSTED = "WS_RETRY_EXHAUSTED"
     SINGLE_ACTIVE_EDITOR_CONFLICT = "SINGLE_ACTIVE_EDITOR_CONFLICT"
+    WS_PROXY_UPSTREAM_UNAVAILABLE = "WS_PROXY_UPSTREAM_UNAVAILABLE"
+    WS_HEARTBEAT_TIMEOUT = "WS_HEARTBEAT_TIMEOUT"
+    WS_MESSAGE_PARSE_ERROR = "WS_MESSAGE_PARSE_ERROR"
+    PROXY_UPSTREAM_ERROR = "PROXY_UPSTREAM_ERROR"
+    MODAL_PROVISION_FAILED = "MODAL_PROVISION_FAILED"
 
 
 @dataclass(frozen=True)
@@ -93,6 +99,36 @@ ERROR_SPECS: Dict[RealtimeErrorCode, RealtimeErrorSpec] = {
             "Another active editor session already owns this sandbox identity. "
             "Finish or terminate that session before creating a new one."
         ),
+    ),
+    RealtimeErrorCode.WS_PROXY_UPSTREAM_UNAVAILABLE: RealtimeErrorSpec(
+        code=RealtimeErrorCode.WS_PROXY_UPSTREAM_UNAVAILABLE,
+        http_status=502,
+        retryable=True,
+        message="Sandbox WebSocket upstream is unavailable. Retrying...",
+    ),
+    RealtimeErrorCode.WS_HEARTBEAT_TIMEOUT: RealtimeErrorSpec(
+        code=RealtimeErrorCode.WS_HEARTBEAT_TIMEOUT,
+        http_status=408,
+        retryable=True,
+        message="WebSocket heartbeat timed out. Reconnecting...",
+    ),
+    RealtimeErrorCode.WS_MESSAGE_PARSE_ERROR: RealtimeErrorSpec(
+        code=RealtimeErrorCode.WS_MESSAGE_PARSE_ERROR,
+        http_status=400,
+        retryable=False,
+        message="Failed to parse WebSocket message.",
+    ),
+    RealtimeErrorCode.PROXY_UPSTREAM_ERROR: RealtimeErrorSpec(
+        code=RealtimeErrorCode.PROXY_UPSTREAM_ERROR,
+        http_status=502,
+        retryable=True,
+        message="Upstream sandbox returned an error. Retry in a few seconds.",
+    ),
+    RealtimeErrorCode.MODAL_PROVISION_FAILED: RealtimeErrorSpec(
+        code=RealtimeErrorCode.MODAL_PROVISION_FAILED,
+        http_status=503,
+        retryable=False,
+        message="Failed to provision Modal sandbox compute.",
     ),
 }
 

--- a/backend/realtime/lifecycle.py
+++ b/backend/realtime/lifecycle.py
@@ -28,8 +28,12 @@ from sqlalchemy.orm import Session
 
 from utils import utc_now
 
+from config.realtime_flags import get_realtime_feature_flags
+
 from .cache_store import SessionCacheStore
 from .errors import RealtimeErrorCode, as_http_exception
+from .modal_registry import get_modal_registry
+from .modal_sandbox import RealtimeModalSandbox
 from .sandbox_manager import SandboxManager
 
 
@@ -56,7 +60,7 @@ class RealtimeLifecycleService:
     # Sandbox + runtime provisioning
     # ---------------------------------------------------------------------
 
-    def create_runtime_for_session(
+    async def create_runtime_for_session(
         self,
         db: Session,
         *,
@@ -105,7 +109,21 @@ class RealtimeLifecycleService:
 
         sandbox.active_session_id = session.id
         sandbox.status = SandboxStatus.RUNNING.value
-        sandbox.tunnel_url = sandbox.tunnel_url or self.sandbox_manager.build_tunnel_url(sandbox.id)
+
+        flags = get_realtime_feature_flags()
+        if flags.modal_provisioning_enabled:
+            controller_base_url = os.getenv("CONTROLLER_BASE_URL", "http://localhost:8000")
+            github_token = os.getenv("GITHUB_TOKEN")
+            modal_sb = await RealtimeModalSandbox.create(
+                sandbox_db_id=sandbox.id,
+                controller_base_url=controller_base_url,
+                github_token=github_token,
+            )
+            sandbox.tunnel_url = modal_sb.tunnel_url
+            await get_modal_registry().register(sandbox.id, modal_sb)
+        else:
+            sandbox.tunnel_url = sandbox.tunnel_url or self.sandbox_manager.build_tunnel_url(sandbox.id)
+
         sandbox.tunnel_token_ttl_seconds = sandbox.tunnel_token_ttl_seconds or 3600
         sandbox.last_heartbeat_at = utc_now()
 
@@ -119,6 +137,8 @@ class RealtimeLifecycleService:
                 "environment": identity.environment,
             }
         )
+        if flags.modal_provisioning_enabled:
+            lifecycle_metadata["modal_sandbox_id"] = modal_sb.modal_sandbox_id
         sandbox.lifecycle_metadata = lifecycle_metadata
 
         git_bootstrap = self.sandbox_manager.ensure_git_bootstrap(
@@ -613,6 +633,14 @@ class RealtimeLifecycleService:
         sandbox.status = SandboxStatus.TERMINATED.value
         sandbox.terminated_at = utc_now()
         sandbox.active_session_id = None
+
+        flags = get_realtime_feature_flags()
+        if flags.modal_provisioning_enabled:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(get_modal_registry().terminate_and_remove(sandbox.id))
+            except RuntimeError:
+                pass
 
         runtimes = (
             db.query(SessionRuntime)

--- a/backend/realtime/modal_registry.py
+++ b/backend/realtime/modal_registry.py
@@ -1,0 +1,47 @@
+"""In-memory registry for active Modal sandbox instances."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, Optional
+
+from .modal_sandbox import RealtimeModalSandbox
+
+logger = logging.getLogger(__name__)
+
+
+class ModalSandboxRegistry:
+    """Thread-safe in-memory mapping from sandbox DB IDs to Modal instances."""
+
+    def __init__(self) -> None:
+        self._sandboxes: Dict[str, RealtimeModalSandbox] = {}
+        self._lock = asyncio.Lock()
+
+    async def register(self, sandbox_db_id: str, sandbox: RealtimeModalSandbox) -> None:
+        async with self._lock:
+            self._sandboxes[sandbox_db_id] = sandbox
+            logger.info("Registered Modal sandbox: db_id=%s modal_id=%s", sandbox_db_id, sandbox.modal_sandbox_id)
+
+    async def get(self, sandbox_db_id: str) -> Optional[RealtimeModalSandbox]:
+        async with self._lock:
+            return self._sandboxes.get(sandbox_db_id)
+
+    async def remove(self, sandbox_db_id: str) -> Optional[RealtimeModalSandbox]:
+        async with self._lock:
+            return self._sandboxes.pop(sandbox_db_id, None)
+
+    async def terminate_and_remove(self, sandbox_db_id: str) -> None:
+        sandbox = await self.remove(sandbox_db_id)
+        if sandbox:
+            await sandbox.terminate()
+
+
+_registry_singleton: Optional[ModalSandboxRegistry] = None
+
+
+def get_modal_registry() -> ModalSandboxRegistry:
+    global _registry_singleton
+    if _registry_singleton is None:
+        _registry_singleton = ModalSandboxRegistry()
+    return _registry_singleton

--- a/backend/realtime/modal_sandbox.py
+++ b/backend/realtime/modal_sandbox.py
@@ -1,0 +1,143 @@
+"""Modal compute provisioning for realtime sandbox sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+import modal
+
+logger = logging.getLogger(__name__)
+
+REALTIME_SANDBOX_IMAGE = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("git", "curl")
+    .pip_install(
+        "fastapi",
+        "uvicorn[standard]",
+        "httpx",
+        "sqlalchemy",
+        "pydantic",
+        "pyyaml",
+        "requests",
+        "websockets",
+        "python-jose[cryptography]",
+        "passlib",
+    )
+    .copy_local_dir("backend/", "/app/backend/")
+    .env({"PYTHONPATH": "/app/backend"})
+)
+
+_modal_app: Optional[modal.App] = None
+_modal_app_lock = asyncio.Lock()
+
+
+async def _call_modal_async(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Call Modal APIs using async variants when available."""
+    aio_fn = getattr(fn, "aio", None)
+    if aio_fn is not None:
+        return await aio_fn(*args, **kwargs)
+    return await asyncio.to_thread(fn, *args, **kwargs)
+
+
+async def _get_modal_app() -> modal.App:
+    """Lazily initialize and cache the Modal app for realtime sandboxes."""
+    global _modal_app
+    if _modal_app is not None:
+        return _modal_app
+
+    async with _modal_app_lock:
+        if _modal_app is None:
+            _modal_app = await _call_modal_async(
+                modal.App.lookup,
+                "yudai-realtime",
+                create_if_missing=True,
+            )
+    return _modal_app
+
+
+@dataclass
+class RealtimeModalSandbox:
+    """Manages a single Modal sandbox running run_sandbox_server.py."""
+
+    _sandbox: modal.Sandbox
+    _tunnel_url: str
+    _modal_sandbox_id: str
+
+    @classmethod
+    async def create(
+        cls,
+        sandbox_db_id: str,
+        controller_base_url: str,
+        github_token: Optional[str] = None,
+        timeout: int = 7200,
+    ) -> "RealtimeModalSandbox":
+        app = await _get_modal_app()
+
+        sandbox_env: Dict[str, str] = {
+            "SANDBOX_ID": sandbox_db_id,
+            "CONTROLLER_BASE_URL": controller_base_url,
+        }
+        if github_token:
+            sandbox_env["GITHUB_TOKEN"] = github_token
+
+        logger.info(
+            "Creating Modal sandbox for db_id=%s controller=%s timeout=%d",
+            sandbox_db_id,
+            controller_base_url,
+            timeout,
+        )
+
+        sandbox = await _call_modal_async(
+            modal.Sandbox.create,
+            "python",
+            "-m",
+            "uvicorn",
+            "run_sandbox_server:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8100",
+            app=app,
+            image=REALTIME_SANDBOX_IMAGE,
+            encrypted_ports=[8100],
+            env=sandbox_env,
+            timeout=timeout,
+            workdir="/app/backend",
+        )
+
+        tunnel_info = sandbox.tunnels()[8100]
+        tunnel_url = tunnel_info.url
+
+        modal_sandbox_id = str(sandbox.object_id)
+        logger.info(
+            "Modal sandbox created: modal_id=%s tunnel_url=%s",
+            modal_sandbox_id,
+            tunnel_url,
+        )
+
+        return cls(
+            _sandbox=sandbox,
+            _tunnel_url=tunnel_url,
+            _modal_sandbox_id=modal_sandbox_id,
+        )
+
+    @property
+    def tunnel_url(self) -> str:
+        return self._tunnel_url
+
+    @property
+    def modal_sandbox_id(self) -> str:
+        return self._modal_sandbox_id
+
+    async def terminate(self) -> None:
+        try:
+            await _call_modal_async(self._sandbox.terminate)
+            logger.info("Modal sandbox terminated: %s", self._modal_sandbox_id)
+        except Exception as e:
+            logger.warning("Failed to terminate Modal sandbox %s: %s", self._modal_sandbox_id, e)
+
+    async def exec(self, command: str) -> Any:
+        return await _call_modal_async(self._sandbox.exec, "bash", "-c", command)

--- a/backend/realtime/sandbox_routes.py
+++ b/backend/realtime/sandbox_routes.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import logging
 import os
 
 from auth.github_oauth import validate_session_token
@@ -10,6 +13,9 @@ from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect
 from sqlalchemy.orm import Session
 
 from .schemas import HealthzResponse
+from .ws_protocol import WSMessageType, build_envelope
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["realtime-sandbox"])
 
@@ -63,3 +69,190 @@ async def websocket_chat(
             )
     except WebSocketDisconnect:
         return
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Unified WS handler (trajectory + chat + agent questions)
+# ---------------------------------------------------------------------------
+
+
+@router.websocket("/sessions/{session_id}/ws/unified")
+async def websocket_unified(
+    websocket: WebSocket,
+    session_id: str,
+    token: str = Query(...),
+    db: Session = Depends(get_db),
+) -> None:
+    """Unified WS endpoint: heartbeat, trajectory polling, bidirectional chat."""
+    user = validate_session_token(db, token)
+    if not user:
+        await websocket.close(code=4401, reason="invalid_session_token")
+        return
+
+    await websocket.accept()
+    await websocket.send_text(
+        build_envelope(WSMessageType.STATUS, {"status": "connected", "session_id": session_id})
+    )
+
+    shutdown = asyncio.Event()
+
+    async def heartbeat_loop() -> None:
+        """Send heartbeat every 3 seconds."""
+        while not shutdown.is_set():
+            try:
+                await websocket.send_text(build_envelope(WSMessageType.HEARTBEAT))
+            except Exception:
+                shutdown.set()
+                return
+            await asyncio.sleep(3)
+
+    async def trajectory_poll_loop() -> None:
+        """Poll solver executor for trajectory updates every 3 seconds."""
+        from solver.solver import solver_manager
+
+        last_message_count = 0
+
+        while not shutdown.is_set():
+            await asyncio.sleep(3)
+            if shutdown.is_set():
+                return
+
+            # Find any active executor for this session's solves
+            # The executor key is (solve_id, run_id) — iterate to find active ones
+            active_executors = solver_manager.get_active_executors()
+            for (solve_id, run_id), executor in active_executors:
+                if not executor.is_active:
+                    continue
+
+                try:
+                    trajectory = await executor.read_trajectory()
+                    if not trajectory:
+                        continue
+
+                    messages = trajectory.get("messages", [])
+                    info = trajectory.get("info", {})
+                    current_count = len(messages)
+
+                    if current_count > last_message_count:
+                        new_messages = messages[last_message_count:]
+                        await websocket.send_text(
+                            build_envelope(
+                                WSMessageType.TRAJECTORY_UPDATE,
+                                {
+                                    "messages": new_messages,
+                                    "info": info,
+                                    "message_count": current_count,
+                                    "new_message_start_index": last_message_count,
+                                },
+                            )
+                        )
+                        last_message_count = current_count
+
+                        # Detect tool calls in new messages
+                        for msg in new_messages:
+                            extra = msg.get("extra", {})
+                            if isinstance(extra, dict) and extra.get("tool_call"):
+                                await websocket.send_text(
+                                    build_envelope(
+                                        WSMessageType.TOOL_CALL,
+                                        {
+                                            "tool_name": extra["tool_call"].get("name", "unknown"),
+                                            "tool_input": extra["tool_call"].get("input", {}),
+                                            "call_id": extra["tool_call"].get("id"),
+                                        },
+                                    )
+                                )
+
+                            if isinstance(extra, dict) and extra.get("agent_question"):
+                                await websocket.send_text(
+                                    build_envelope(
+                                        WSMessageType.AGENT_QUESTION,
+                                        {
+                                            "question_id": extra["agent_question"].get("id", ""),
+                                            "question_text": extra["agent_question"].get("text", ""),
+                                            "options": extra["agent_question"].get("options", []),
+                                        },
+                                    )
+                                )
+
+                except Exception as e:
+                    logger.debug("Trajectory poll error: %s", e)
+
+            # Check if all executors finished
+            if not any(ex.is_active for (_, _), ex in active_executors):
+                if active_executors:
+                    # Had executors but they all finished
+                    try:
+                        await websocket.send_text(
+                            build_envelope(WSMessageType.STATUS, {"status": "completed"})
+                        )
+                        await websocket.send_text(build_envelope(WSMessageType.DONE))
+                    except Exception:
+                        pass
+                    shutdown.set()
+                    return
+
+    async def receive_loop() -> None:
+        """Listen for client messages (chat_message, user_response)."""
+        while not shutdown.is_set():
+            try:
+                raw = await websocket.receive_text()
+            except WebSocketDisconnect:
+                shutdown.set()
+                return
+            except Exception:
+                shutdown.set()
+                return
+
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                await websocket.send_text(
+                    build_envelope(
+                        WSMessageType.ERROR,
+                        {"message": "Invalid JSON", "code": "WS_MESSAGE_PARSE_ERROR"},
+                    )
+                )
+                continue
+
+            msg_type = msg.get("type")
+
+            if msg_type == WSMessageType.CHAT_MESSAGE.value:
+                content = msg.get("payload", {}).get("content", "")
+                await websocket.send_text(
+                    build_envelope(
+                        WSMessageType.STATUS,
+                        {"status": "received", "detail": f"Chat message received ({len(content)} chars)"},
+                    )
+                )
+
+            elif msg_type == WSMessageType.USER_RESPONSE.value:
+                await websocket.send_text(
+                    build_envelope(
+                        WSMessageType.STATUS,
+                        {"status": "received", "detail": "User response acknowledged"},
+                    )
+                )
+
+            else:
+                await websocket.send_text(
+                    build_envelope(
+                        WSMessageType.ERROR,
+                        {"message": f"Unknown message type: {msg_type}"},
+                    )
+                )
+
+    try:
+        await asyncio.gather(
+            heartbeat_loop(),
+            trajectory_poll_loop(),
+            receive_loop(),
+        )
+    except Exception as e:
+        logger.warning("Unified WS error for session %s: %s", session_id, e)
+    finally:
+        shutdown.set()
+        try:
+            await websocket.close()
+        except Exception:
+            pass

--- a/backend/realtime/schemas.py
+++ b/backend/realtime/schemas.py
@@ -25,6 +25,7 @@ class SandboxResponse(BaseModel):
     tunnel_token_ttl_seconds: int = 3600
     last_heartbeat_at: Optional[datetime] = None
     terminated_at: Optional[datetime] = None
+    modal_sandbox_id: Optional[str] = None
 
 
 class TunnelResolveResponse(BaseModel):
@@ -62,6 +63,7 @@ class RuntimeResponse(BaseModel):
     identity_key: str
     status: str
     tunnel_url: Optional[str] = None
+    proxy_base_url: Optional[str] = None
     token_ttl_seconds: int = 3600
     tunnel_expires_at: Optional[datetime] = None
     completion_issue_created: bool = False

--- a/backend/realtime/ws_protocol.py
+++ b/backend/realtime/ws_protocol.py
@@ -1,0 +1,104 @@
+"""WebSocket message protocol for unified realtime communication."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from utils import utc_now
+
+
+class WSMessageType(str, Enum):
+    # Client -> Server
+    CHAT_MESSAGE = "chat_message"
+    USER_RESPONSE = "user_response"
+
+    # Server -> Client
+    TRAJECTORY_UPDATE = "trajectory_update"
+    TOOL_CALL = "tool_call"
+    AGENT_QUESTION = "agent_question"
+    STATUS = "status"
+    HEARTBEAT = "heartbeat"
+    ERROR = "error"
+    DONE = "done"
+
+
+class WSEnvelope(BaseModel):
+    """Top-level message envelope for all WS communication."""
+
+    type: WSMessageType
+    ts: datetime = Field(default_factory=utc_now)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    seq: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Typed payloads (server -> client)
+# ---------------------------------------------------------------------------
+
+
+class TrajectoryUpdatePayload(BaseModel):
+    messages: List[Dict[str, Any]]
+    info: Dict[str, Any] = Field(default_factory=dict)
+    message_count: int = 0
+    new_message_start_index: int = 0
+
+
+class ToolCallPayload(BaseModel):
+    tool_name: str
+    tool_input: Dict[str, Any] = Field(default_factory=dict)
+    call_id: Optional[str] = None
+
+
+class AgentQuestionPayload(BaseModel):
+    question_id: str
+    question_text: str
+    options: List[str] = Field(default_factory=list)
+
+
+class StatusPayload(BaseModel):
+    status: str
+    detail: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Typed payloads (client -> server)
+# ---------------------------------------------------------------------------
+
+
+class ChatMessagePayload(BaseModel):
+    content: str
+
+
+class UserResponsePayload(BaseModel):
+    question_id: str
+    answer: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_seq_counter: int = 0
+
+
+def _next_seq() -> int:
+    global _seq_counter
+    _seq_counter += 1
+    return _seq_counter
+
+
+def build_envelope(
+    msg_type: WSMessageType,
+    payload: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Serialize a WSEnvelope to JSON string."""
+    envelope = WSEnvelope(
+        type=msg_type,
+        payload=payload or {},
+        seq=_next_seq(),
+    )
+    return envelope.model_dump_json()

--- a/backend/solver/manager.py
+++ b/backend/solver/manager.py
@@ -806,6 +806,16 @@ class DefaultSolverManager(SolverManager):
             return None
         return state.executors.get(run_id)
 
+    def get_active_executors(
+        self,
+    ) -> List[tuple[tuple[str, str], HeadlessSandboxExecutor]]:
+        """Return all currently registered executors as ((solve_id, run_id), executor) pairs."""
+        results: List[tuple[tuple[str, str], HeadlessSandboxExecutor]] = []
+        for solve_id, state in self._tasks.items():
+            for run_id, executor in state.executors.items():
+                results.append(((solve_id, run_id), executor))
+        return results
+
     async def _cleanup_task(self, solve_id: str):
         async with self._lock:
             self._tasks.pop(solve_id, None)

--- a/backend/solver/solver.py
+++ b/backend/solver/solver.py
@@ -188,7 +188,19 @@ async def stream_trajectory(
 
     Authentication via ?token= query parameter (EventSource doesn't support headers).
     Sends trajectory_update events with new messages every 3s.
+
+    When ws_unified_enabled is true and sse_stream_enabled is false, returns 410 Gone
+    to signal clients to use the unified WebSocket endpoint instead.
     """
+    from config.realtime_flags import get_realtime_feature_flags
+
+    flags = get_realtime_feature_flags()
+    if flags.ws_unified_enabled and not flags.sse_stream_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="SSE streaming is deprecated. Use the unified WebSocket endpoint.",
+        )
+
     return StreamingResponse(
         _trajectory_stream_generator(request, solve_id, run_id),
         media_type="text/event-stream",

--- a/src/components/TrajectoryViewer.tsx
+++ b/src/components/TrajectoryViewer.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
-import { FileText, ChevronRight, ChevronDown, DollarSign, MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Radio } from 'lucide-react';
+import { FileText, ChevronRight, ChevronDown, DollarSign, MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Radio, Wrench, HelpCircle } from 'lucide-react';
 import { useTrajectoryStream } from '../hooks/useTrajectoryStream';
-import type { TrajectoryData } from '../types/sessionTypes';
+import { useSessionWebSocket } from '../hooks/useSessionWebSocket';
+import { realtimeFeatureFlags } from '../config/realtimeFlags';
+import type { TrajectoryData, ToolCallInfo, AgentQuestionInfo } from '../types/sessionTypes';
 import trajectoryData from '../data/last_mini_run.traj.json';
 
 interface TrajectoryViewerProps {
@@ -25,18 +27,29 @@ export const TrajectoryViewer: React.FC<TrajectoryViewerProps> = ({
   const [expandedMessages, setExpandedMessages] = useState<Set<number>>(new Set());
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Live streaming hook
-  const {
-    trajectory: liveTrajectory,
-    streamStatus,
-    error: streamError,
-    messageCount: liveMessageCount,
-  } = useTrajectoryStream({
+  const useWsMode = isLive && realtimeFeatureFlags.wsUnifiedEnabled;
+
+  // WS unified hook (Phase 5)
+  const wsStream = useSessionWebSocket({
+    sessionId,
+    enabled: useWsMode,
+  });
+
+  // SSE streaming hook (legacy)
+  const sseStream = useTrajectoryStream({
     sessionId,
     solveId,
     runId,
-    enabled: isLive,
+    enabled: isLive && !realtimeFeatureFlags.wsUnifiedEnabled,
   });
+
+  // Unify the two streams
+  const liveTrajectory = useWsMode ? wsStream.trajectory : sseStream.trajectory;
+  const streamStatus = useWsMode ? wsStream.status : sseStream.streamStatus;
+  const streamError = useWsMode ? wsStream.error : sseStream.error;
+  const liveMessageCount = useWsMode ? wsStream.messageCount : sseStream.messageCount;
+  const toolCalls: ToolCallInfo[] = useWsMode ? wsStream.toolCalls : [];
+  const agentQuestion: AgentQuestionInfo | null = useWsMode ? wsStream.agentQuestion : null;
 
   // Static fallback data
   const [staticState, setStaticState] = useState<{
@@ -241,6 +254,47 @@ export const TrajectoryViewer: React.FC<TrajectoryViewerProps> = ({
           </div>
         )}
       </div>
+
+      {/* Agent Question (WS mode only) */}
+      {agentQuestion && (
+        <div className="mx-4 mt-2 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+          <div className="flex items-center gap-2 mb-2">
+            <HelpCircle className="w-4 h-4 text-amber-400" />
+            <p className="text-sm font-medium text-amber-300">Agent Question</p>
+          </div>
+          <p className="text-sm text-fg mb-2">{agentQuestion.question_text}</p>
+          {agentQuestion.options.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {agentQuestion.options.map((opt) => (
+                <button
+                  key={opt}
+                  onClick={() => wsStream.sendUserResponse(agentQuestion.question_id, opt)}
+                  className="px-3 py-1 text-xs bg-amber-500/20 hover:bg-amber-500/30 border border-amber-500/40 rounded-md text-amber-200 transition-colors"
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Recent Tool Calls (WS mode only) */}
+      {toolCalls.length > 0 && (
+        <div className="mx-4 mt-2 p-3 bg-zinc-800/50 border border-zinc-700/50 rounded-lg">
+          <div className="flex items-center gap-2 mb-2">
+            <Wrench className="w-4 h-4 text-fg/60" />
+            <p className="text-xs font-medium text-fg/60">Recent Tool Calls ({toolCalls.length})</p>
+          </div>
+          <div className="space-y-1">
+            {toolCalls.slice(-5).map((tc, i) => (
+              <div key={i} className="text-xs text-fg/50 font-mono">
+                {tc.tool_name}({Object.keys(tc.tool_input).join(', ')})
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Messages List */}
       <div className="flex-1 overflow-y-auto p-4">

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -44,6 +44,7 @@ export const API = {
     CLEANUP: `${API_BASE}/controller/sandboxes/cleanup`,
     RUNTIME_ENSURE: `${API_BASE}/controller/sessions/{sessionId}/runtime`,
     RUNTIME_DETAIL: `${API_BASE}/controller/sessions/{sessionId}/runtime`,
+    PROXY: `${API_BASE}/controller/proxy/sessions/{sessionId}`,
   },
   SYSTEM: {
     HEALTH: `${API_BASE}/health`,

--- a/src/config/realtimeFlags.ts
+++ b/src/config/realtimeFlags.ts
@@ -12,6 +12,8 @@ export interface RealtimeFeatureFlags {
   tunnelModeEnabled: boolean;
   wsChatEnabled: boolean;
   sseStreamEnabled: boolean;
+  controllerProxyEnabled: boolean;
+  wsUnifiedEnabled: boolean;
   contractVersion: string;
 }
 
@@ -27,6 +29,14 @@ export const realtimeFeatureFlags: RealtimeFeatureFlags = {
   wsChatEnabled: parseFlag(import.meta.env.VITE_REALTIME_WS_CHAT_ENABLED, false),
   sseStreamEnabled: parseFlag(
     import.meta.env.VITE_REALTIME_SSE_STREAM_ENABLED,
+    false
+  ),
+  controllerProxyEnabled: parseFlag(
+    import.meta.env.VITE_REALTIME_CONTROLLER_PROXY_ENABLED,
+    false
+  ),
+  wsUnifiedEnabled: parseFlag(
+    import.meta.env.VITE_REALTIME_WS_UNIFIED_ENABLED,
     false
   ),
   contractVersion: (

--- a/src/hooks/useSessionQueries.ts
+++ b/src/hooks/useSessionQueries.ts
@@ -53,6 +53,17 @@ const buildSessionTargetUrl = (
   params: Record<string, string>
 ): string => {
   const resolved = buildApiUrl(endpoint, params);
+
+  if (realtimeFeatureFlags.controllerProxyEnabled) {
+    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const parsed = new URL(resolved, origin);
+    const match = parsed.pathname.match(/\/daifu\/sessions\/([^/]+)(\/.*)?$/);
+    if (match) {
+      const [, sessionId, rest] = match;
+      return `/api/controller/proxy/sessions/${sessionId}/sessions/${sessionId}${rest || ''}${parsed.search}`;
+    }
+  }
+
   if (!realtimeFeatureFlags.tunnelModeEnabled) {
     return resolved;
   }

--- a/src/hooks/useSessionWebSocket.ts
+++ b/src/hooks/useSessionWebSocket.ts
@@ -1,0 +1,249 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useAuthStore } from '../stores/authStore';
+import type {
+  TrajectoryData,
+  ToolCallInfo,
+  AgentQuestionInfo,
+  WSEnvelope,
+} from '../types/sessionTypes';
+
+type WSStatus = 'idle' | 'connecting' | 'connected' | 'streaming' | 'completed' | 'error';
+
+interface UseSessionWebSocketParams {
+  sessionId: string;
+  enabled: boolean;
+}
+
+interface UseSessionWebSocketResult {
+  trajectory: TrajectoryData | null;
+  status: WSStatus;
+  error: string | null;
+  messageCount: number;
+  toolCalls: ToolCallInfo[];
+  agentQuestion: AgentQuestionInfo | null;
+  sendChatMessage: (content: string) => void;
+  sendUserResponse: (questionId: string, answer: string) => void;
+  disconnect: () => void;
+}
+
+const MAX_RECONNECT_ATTEMPTS = 10;
+const HEARTBEAT_TIMEOUT_MS = 10_000;
+
+export function useSessionWebSocket({
+  sessionId,
+  enabled,
+}: UseSessionWebSocketParams): UseSessionWebSocketResult {
+  const [trajectory, setTrajectory] = useState<TrajectoryData | null>(null);
+  const [status, setStatus] = useState<WSStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [messageCount, setMessageCount] = useState(0);
+  const [toolCalls, setToolCalls] = useState<ToolCallInfo[]>([]);
+  const [agentQuestion, setAgentQuestion] = useState<AgentQuestionInfo | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const heartbeatTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sessionToken = useAuthStore((state) => state.sessionToken);
+
+  const resetHeartbeatTimer = useCallback(() => {
+    if (heartbeatTimerRef.current) {
+      clearTimeout(heartbeatTimerRef.current);
+    }
+    heartbeatTimerRef.current = setTimeout(() => {
+      // No message in 10s — force reconnect
+      if (wsRef.current) {
+        wsRef.current.close(4000, 'heartbeat_timeout');
+      }
+    }, HEARTBEAT_TIMEOUT_MS);
+  }, []);
+
+  const cleanup = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    if (heartbeatTimerRef.current) {
+      clearTimeout(heartbeatTimerRef.current);
+      heartbeatTimerRef.current = null;
+    }
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+  }, []);
+
+  const disconnect = useCallback(() => {
+    cleanup();
+    reconnectAttemptsRef.current = MAX_RECONNECT_ATTEMPTS; // prevent reconnect
+    setStatus('idle');
+  }, [cleanup]);
+
+  const connect = useCallback(() => {
+    if (!sessionToken || !sessionId) return;
+
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = window.location.host;
+    const wsUrl =
+      `${protocol}//${host}/api/controller/proxy/sessions/${sessionId}/ws/sessions/${sessionId}/ws/unified?token=${encodeURIComponent(sessionToken)}`;
+
+    setStatus('connecting');
+    setError(null);
+
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setStatus('connected');
+      reconnectAttemptsRef.current = 0;
+      resetHeartbeatTimer();
+    };
+
+    ws.onmessage = (event) => {
+      resetHeartbeatTimer();
+
+      let envelope: WSEnvelope;
+      try {
+        envelope = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      switch (envelope.type) {
+        case 'status': {
+          const s = (envelope.payload as { status?: string }).status;
+          if (s === 'connected') setStatus('connected');
+          if (s === 'completed') setStatus('completed');
+          break;
+        }
+
+        case 'heartbeat':
+          // Timer already reset above
+          break;
+
+        case 'trajectory_update': {
+          setStatus('streaming');
+          const payload = envelope.payload as {
+            messages: Array<{ role: string; content: string; extra?: Record<string, unknown> }>;
+            info: Record<string, unknown>;
+            message_count: number;
+          };
+
+          setTrajectory((prev) => {
+            if (!prev) {
+              return {
+                info: payload.info as TrajectoryData['info'],
+                messages: payload.messages,
+              };
+            }
+            return {
+              info: payload.info as TrajectoryData['info'],
+              messages: [...prev.messages, ...payload.messages],
+            };
+          });
+          setMessageCount(payload.message_count);
+          break;
+        }
+
+        case 'tool_call': {
+          const tc = envelope.payload as ToolCallInfo;
+          setToolCalls((prev) => [...prev, tc]);
+          break;
+        }
+
+        case 'agent_question': {
+          const aq = envelope.payload as AgentQuestionInfo;
+          setAgentQuestion(aq);
+          break;
+        }
+
+        case 'error': {
+          const msg = (envelope.payload as { message?: string }).message || 'Unknown error';
+          setError(msg);
+          break;
+        }
+
+        case 'done':
+          setStatus('completed');
+          cleanup();
+          break;
+      }
+    };
+
+    ws.onclose = () => {
+      wsRef.current = null;
+      if (heartbeatTimerRef.current) {
+        clearTimeout(heartbeatTimerRef.current);
+      }
+
+      if (
+        reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS &&
+        status !== 'completed'
+      ) {
+        const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 30_000);
+        reconnectAttemptsRef.current += 1;
+        setStatus('connecting');
+        reconnectTimerRef.current = setTimeout(connect, delay);
+      } else if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
+        setStatus('error');
+        setError('Connection lost after 10 reconnect attempts.');
+      }
+    };
+
+    ws.onerror = () => {
+      // onclose will fire after this
+    };
+  }, [sessionToken, sessionId, cleanup, resetHeartbeatTimer, status]);
+
+  useEffect(() => {
+    if (enabled) {
+      reconnectAttemptsRef.current = 0;
+      connect();
+    } else {
+      cleanup();
+      setStatus('idle');
+    }
+    return cleanup;
+  }, [enabled, sessionId, sessionToken]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const sendChatMessage = useCallback(
+    (content: string) => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(
+          JSON.stringify({
+            type: 'chat_message',
+            payload: { content },
+          })
+        );
+      }
+    },
+    []
+  );
+
+  const sendUserResponse = useCallback(
+    (questionId: string, answer: string) => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(
+          JSON.stringify({
+            type: 'user_response',
+            payload: { question_id: questionId, answer },
+          })
+        );
+      }
+      setAgentQuestion(null);
+    },
+    []
+  );
+
+  return {
+    trajectory,
+    status,
+    error,
+    messageCount,
+    toolCalls,
+    agentQuestion,
+    sendChatMessage,
+    sendUserResponse,
+    disconnect,
+  };
+}

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -111,6 +111,17 @@ const buildSessionTargetUrl = (
   params: Record<string, string>
 ): string => {
   const resolved = buildApiUrl(endpoint, params);
+
+  if (realtimeFeatureFlags.controllerProxyEnabled) {
+    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const parsed = new URL(resolved, origin);
+    const match = parsed.pathname.match(/\/daifu\/sessions\/([^/]+)(\/.*)?$/);
+    if (match) {
+      const [, sessionId, rest] = match;
+      return `/api/controller/proxy/sessions/${sessionId}/sessions/${sessionId}${rest || ''}${parsed.search}`;
+    }
+  }
+
   if (!realtimeFeatureFlags.tunnelModeEnabled) {
     return resolved;
   }
@@ -439,7 +450,11 @@ export const useSessionStore = create<SessionState>()(
                 )
               );
 
-              if (realtimeFeatureFlags.tunnelModeEnabled && !runtime?.tunnel_url) {
+              if (
+                !realtimeFeatureFlags.controllerProxyEnabled &&
+                realtimeFeatureFlags.tunnelModeEnabled &&
+                !runtime?.tunnel_url
+              ) {
                 throw new AppError('TUNNEL_UNAVAILABLE', TUNNEL_UNAVAILABLE_MESSAGE);
               }
             }
@@ -501,7 +516,11 @@ export const useSessionStore = create<SessionState>()(
                 )
               );
 
-              if (realtimeFeatureFlags.tunnelModeEnabled && !runtime?.tunnel_url) {
+              if (
+                !realtimeFeatureFlags.controllerProxyEnabled &&
+                realtimeFeatureFlags.tunnelModeEnabled &&
+                !runtime?.tunnel_url
+              ) {
                 throw new AppError('TUNNEL_UNAVAILABLE', TUNNEL_UNAVAILABLE_MESSAGE);
               }
             }
@@ -595,7 +614,11 @@ export const useSessionStore = create<SessionState>()(
                 )
               );
 
-              if (realtimeFeatureFlags.tunnelModeEnabled && !runtime?.tunnel_url) {
+              if (
+                !realtimeFeatureFlags.controllerProxyEnabled &&
+                realtimeFeatureFlags.tunnelModeEnabled &&
+                !runtime?.tunnel_url
+              ) {
                 throw new AppError('TUNNEL_UNAVAILABLE', TUNNEL_UNAVAILABLE_MESSAGE);
               }
             }

--- a/src/types/sessionTypes.ts
+++ b/src/types/sessionTypes.ts
@@ -671,6 +671,40 @@ export interface CancelSolveResponse {
 }
 
 // ============================================================================
+// WS UNIFIED PROTOCOL TYPES
+// ============================================================================
+
+export type WSMessageType =
+  | 'chat_message'
+  | 'user_response'
+  | 'trajectory_update'
+  | 'tool_call'
+  | 'agent_question'
+  | 'status'
+  | 'heartbeat'
+  | 'error'
+  | 'done';
+
+export interface WSEnvelope {
+  type: WSMessageType;
+  ts: string;
+  payload: Record<string, unknown>;
+  seq: number;
+}
+
+export interface ToolCallInfo {
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  call_id?: string;
+}
+
+export interface AgentQuestionInfo {
+  question_id: string;
+  question_text: string;
+  options: string[];
+}
+
+// ============================================================================
 // TRAJECTORY STREAMING TYPES
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- **Modal compute provisioning**: Real sandbox creation via `modal.Sandbox.create()` with encrypted tunnel, flag-gated behind `REALTIME_MODAL_PROVISIONING_ENABLED`
- **Controller HTTP/WS reverse proxy**: Same-origin proxy eliminating CORS issues, flag-gated behind `REALTIME_CONTROLLER_PROXY_ENABLED`
- **Unified WS protocol**: Bidirectional WebSocket replacing SSE for trajectory streaming, tool calls, and agent questions, flag-gated behind `REALTIME_WS_UNIFIED_ENABLED`

All flags default to `false` — zero behavior change until opted in.

---

## New Files (4)

| File | Lines | Purpose |
|------|-------|---------|
| `backend/realtime/ws_protocol.py` | 104 | `WSMessageType` enum, `WSEnvelope` model, typed payloads, `build_envelope()` |
| `backend/realtime/modal_sandbox.py` | 143 | Modal image definition + `RealtimeModalSandbox.create()` / `terminate()` / `exec()` |
| `backend/realtime/modal_registry.py` | 47 | Async in-memory registry mapping sandbox DB IDs to live Modal instances |
| `src/hooks/useSessionWebSocket.ts` | 249 | Frontend WS hook: exponential backoff reconnect, 10s heartbeat timeout, typed dispatch |

## Modified Files (14)

| File | Delta | What changed |
|------|-------|-------------|
| `backend/config/realtime_flags.py` | +13 | Add `modal_provisioning_enabled`, `controller_proxy_enabled`, `ws_unified_enabled` |
| `backend/realtime/errors.py` | +36 | Add 5 error codes (`WS_PROXY_UPSTREAM_UNAVAILABLE`, `WS_HEARTBEAT_TIMEOUT`, `WS_MESSAGE_PARSE_ERROR`, `PROXY_UPSTREAM_ERROR`, `MODAL_PROVISION_FAILED`), deprecate SSE codes |
| `backend/realtime/schemas.py` | +2 | Add `modal_sandbox_id` on `SandboxResponse`, `proxy_base_url` on `RuntimeResponse` |
| `backend/realtime/lifecycle.py` | +30/−2 | `create_runtime_for_session` → async, flag-gated Modal create + terminate |
| `backend/realtime/controller_routes.py` | +179/−8 | HTTP reverse proxy, WS bidirectional relay, async `create_sandbox`/`ensure_runtime` |
| `backend/realtime/sandbox_routes.py` | +193 | Unified WS handler `/ws/unified` with heartbeat, trajectory poll, chat receive |
| `backend/solver/manager.py` | +10 | `get_active_executors()` returning all live `((solve_id, run_id), executor)` pairs |
| `backend/solver/solver.py` | +12 | Gate SSE with 410 Gone when `ws_unified_enabled && !sse_stream_enabled` |
| `src/config/realtimeFlags.ts` | +10 | Add `controllerProxyEnabled`, `wsUnifiedEnabled` |
| `src/config/api.ts` | +1 | Add `PROXY` endpoint to `CONTROLLER` section |
| `src/stores/sessionStore.ts` | +26/−3 | Proxy-aware `buildSessionTargetUrl`, relax `tunnel_url` requirement when proxy active |
| `src/hooks/useSessionQueries.ts` | +11 | Proxy-aware duplicate `buildSessionTargetUrl` |
| `src/types/sessionTypes.ts` | +34 | `WSMessageType`, `WSEnvelope`, `ToolCallInfo`, `AgentQuestionInfo` |
| `src/components/TrajectoryViewer.tsx` | +64/−10 | Dual-mode WS/SSE via flag, agent question UI, tool call display |

## Feature Flags

| Backend Env Var | Frontend Env Var | Controls |
|----------------|-----------------|----------|
| `REALTIME_MODAL_PROVISIONING_ENABLED` | — | Real Modal sandbox creation via `modal.Sandbox.create()` |
| `REALTIME_CONTROLLER_PROXY_ENABLED` | `VITE_REALTIME_CONTROLLER_PROXY_ENABLED` | HTTP/WS reverse proxy (same origin, no CORS) |
| `REALTIME_WS_UNIFIED_ENABLED` | `VITE_REALTIME_WS_UNIFIED_ENABLED` | Unified WS protocol, SSE deprecation |

## Architecture

```
Phase 0 (Foundations)
  ├──> Phase 1 (Modal Provisioning)     ─┐
  ├──> Phase 2 (HTTP Proxy)              ├──> Phase 3 (WS Proxy) ─┐
  └──> Phase 4 (WS Protocol - Sandbox)  ─┘                        │
                                          Phase 5 (WS Frontend) <──┘
                                            │
                                          Phase 6 (SSE Cleanup)
```

## Test plan

- [ ] All flags default false — zero behavior change on existing flows
- [ ] Enable `REALTIME_MODAL_PROVISIONING_ENABLED` → verify Modal sandbox creation returns real tunnel URL
- [ ] Enable `REALTIME_CONTROLLER_PROXY_ENABLED` → `GET /controller/proxy/sessions/{id}/healthz` proxies to sandbox
- [ ] Enable `REALTIME_WS_UNIFIED_ENABLED` → WS heartbeat every 3s, trajectory updates stream through
- [ ] SSE endpoint returns 410 Gone when `ws_unified=true, sse_stream=false`
- [ ] Frontend `TrajectoryViewer` switches between WS and SSE modes correctly
- [ ] WS reconnect fires with exponential backoff (1s, 2s, 4s...) up to 10 attempts
- [ ] 10s heartbeat timeout triggers client force-reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)